### PR TITLE
[1.19]making old aether dialog system

### DIFF
--- a/src/main/java/com/gildedgames/aetherii/api/SceneInstance.java
+++ b/src/main/java/com/gildedgames/aetherii/api/SceneInstance.java
@@ -1,0 +1,103 @@
+package com.gildedgames.aetherii.api;
+
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.gildedgames.aetherii.api.dialog.IDialogButton;
+import com.gildedgames.aetherii.api.dialog.IDialogLine;
+import com.gildedgames.aetherii.api.dialog.IDialogNode;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+import com.gildedgames.aetherii.api.dialog.scene.ISceneInstance;
+import org.apache.commons.lang3.Validate;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class SceneInstance implements ISceneInstance {
+	private final TalkableController controller;
+
+	private final IDialogScene scene;
+
+	private IDialogNode node;
+
+	private List<IDialogLine> lines;
+
+	private Collection<IDialogButton> buttons;
+
+	private Collection<IDialogAction> endActions;
+
+	private int index;
+
+
+	protected SceneInstance(final TalkableController controller, final IDialogScene scene) {
+
+		this.controller = controller;
+		this.scene = scene;
+
+		this.setNode(this.scene.getStartingNode());
+	}
+
+	@Override
+	public IDialogScene getScene() {
+		return this.scene;
+	}
+
+	@Override
+	public IDialogNode getNode() {
+		return this.node;
+	}
+
+	protected void setNode(final IDialogNode node) {
+		Validate.notNull(node);
+
+		this.node = node;
+
+		this.lines = node.getLines();
+		this.buttons = node.getButtons();
+		this.endActions = node.getEndActions();
+
+		this.index = 0;
+
+		this.controller.updateListeners();
+	}
+
+
+	@Override
+	public IDialogLine getLine() {
+		return this.lines.get(this.index);
+	}
+
+	@Override
+	public boolean isDoneReading() {
+		return this.index >= this.lines.size() - 1;
+	}
+
+	@Override
+	public void navigate(final String nodeId) {
+		final Optional<IDialogNode> node = this.scene.getNode(nodeId);
+
+		this.setNode(node.orElseThrow(() ->
+				new IllegalArgumentException("Node " + nodeId + " doesn't exist")));
+	}
+
+	@Override
+	public void forwards() {
+		if (this.isDoneReading()) {
+			if (this.buttons.size() <= 0) {
+				IDialogNode node = this.getNode();
+
+				for (final IDialogAction action : this.endActions) {
+					action.performAction(this.controller);
+				}
+
+				// Make sure actions haven't navigated somewhere
+				if (this.getNode() == node) {
+					this.setNode(this.scene.getStartingNode());
+				}
+			}
+		} else {
+			this.index++;
+
+			this.controller.updateListeners();
+		}
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/api/TalkableController.java
+++ b/src/main/java/com/gildedgames/aetherii/api/TalkableController.java
@@ -1,0 +1,217 @@
+package com.gildedgames.aetherii.api;
+
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.gildedgames.aetherii.api.dialog.IDialogButton;
+import com.gildedgames.aetherii.api.dialog.IDialogChangeListener;
+import com.gildedgames.aetherii.api.dialog.IDialogCondition;
+import com.gildedgames.aetherii.api.dialog.IDialogLine;
+import com.gildedgames.aetherii.api.dialog.IDialogNode;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+import com.gildedgames.aetherii.api.dialog.scene.ISceneInstance;
+import com.gildedgames.aetherii.api.entity.NormalTalker;
+import com.gildedgames.aetherii.api.entity.TalkableMob;
+import com.gildedgames.aetherii.client.screen.DialogScreen;
+import com.gildedgames.aetherii.register.ContentRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.apache.commons.lang3.Validate;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TalkableController implements NormalTalker {
+	private ISceneInstance sceneInstance;
+	private final Set<IDialogChangeListener> listeners = new HashSet<>();
+	private Level level;
+
+	protected final TalkableMob talkableMob;
+
+	public TalkableController(TalkableMob talkableMob) {
+		this.talkableMob = talkableMob;
+	}
+
+	public void activateButton(final IDialogButton button) {
+		if (talkableMob instanceof LivingEntity) {
+			// Make sure this node actually contains the button
+			Validate.isTrue(this.sceneInstance.getNode().getButtons().contains(button));
+
+			if (((LivingEntity) talkableMob).level.isClientSide()) {
+				//Networking.sendPacketToServer(new PacketActivateButton(button.getLabel()));
+
+				final Collection<IDialogAction> actions = button.getActions();
+
+				for (final IDialogAction action : actions) {
+					action.performAction(this);
+				}
+			}
+
+			if (!this.conditionsMet(button)) {
+				return;
+			}
+
+			if (!((LivingEntity) talkableMob).level.isClientSide()) {
+				//Networking.sendPacketToPlayer(new PacketActivateButton(button.getLabel()), (EntityPlayerMP) this.getEntity());
+
+				final Collection<IDialogAction> actions = button.getActions();
+
+				for (final IDialogAction action : actions) {
+					action.performAction(this);
+				}
+			}
+		}
+	}
+
+	public boolean conditionsMet(IDialogButton button) {
+		/*if(talkableMob instanceof LivingEntity) {
+			if (((LivingEntity) talkableMob).level.isClientSide()) {
+				if (this.sceneInstance == null) {
+					throw new NullPointerException("Scene instance is null in activateButton()");
+				}
+
+				if(this.talkableMob.getTalkingUUID().isEmpty()){
+					return false;
+				}
+
+				if (!this.sceneInstance.getConditionsMet().containsKey(button.getLabel())) {
+					return false;
+				}
+
+				return this.sceneInstance.getConditionsMet().get(button.getLabel()) == this.talkableMob.getTalkingUUID().get();
+			}
+		}*/
+
+		boolean flag = false;
+
+		for (IDialogCondition condition : button.getOrConditions()) {
+			if (condition.isMet(this)) {
+				flag = true;
+				break;
+			}
+		}
+
+		for (IDialogCondition condition : button.getConditions()) {
+			if (!condition.isMet(this)) {
+				flag = false;
+				break;
+			} else {
+				flag = true;
+			}
+		}
+
+		return flag || (button.getConditions().isEmpty() && button.getOrConditions().isEmpty());
+	}
+
+	protected void updateListeners() {
+		for (final IDialogChangeListener listener : this.listeners) {
+			listener.onDialogChanged();
+		}
+	}
+
+	public void advance() {
+		if (this.getLevel().isClientSide()) {
+			//Networking.sendPacketToServer(new PacketAdvance());
+			if (this.sceneInstance != null) {
+				this.sceneInstance.forwards();
+			}
+		} else {
+			//Networking.sendPacketToPlayer(new PacketAdvance(), (EntityPlayerMP) this.getDialogPlayer());
+
+			if (this.sceneInstance != null) {
+				this.sceneInstance.forwards();
+			}
+		}
+	}
+
+	public IDialogNode getCurrentNode() {
+		return this.sceneInstance.getNode();
+	}
+
+	public IDialogLine getCurrentLine() {
+		return this.sceneInstance.getLine();
+	}
+
+	public boolean isNodeFinished() {
+		if (this.sceneInstance == null) {
+			return false;
+		}
+
+		return this.sceneInstance.isDoneReading();
+	}
+
+	@Override
+	public IDialogScene getCurrentScene() {
+		return this.sceneInstance != null ? this.sceneInstance.getScene() : null;
+	}
+
+	@Override
+	public ISceneInstance getCurrentSceneInstance() {
+		return this.sceneInstance;
+	}
+
+
+	public void openScene(Player player, TalkableMob livingEntity, final ResourceLocation path, String startingNodeId) {
+		final IDialogScene scene = ContentRegistry.getDialogManager().getScene(path).orElseThrow(() ->
+				new IllegalArgumentException("Couldn't getByte scene " + path));
+
+		scene.setStartingNode(startingNodeId);
+
+		if (player.level.isClientSide()) {
+			this.openSceneClient(player, livingEntity, path, scene);
+		} else if (!player.level.isClientSide()) {
+			this.openSceneServer(player, livingEntity, path, scene);
+		}
+
+		this.updateListeners();
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	private void openSceneClient(Player player, TalkableMob livingEntity, final ResourceLocation res, final IDialogScene scene) {
+		this.sceneInstance = new SceneInstance(this, scene);
+
+		Minecraft.getInstance().setScreen(new DialogScreen(player, livingEntity));
+	}
+
+	private void openSceneServer(Player player, TalkableMob livingEntity, final ResourceLocation res, final IDialogScene scene) {
+		this.sceneInstance = new SceneInstance(this, scene);
+
+		/*if(livingEntity instanceof LivingEntity) {
+			OpenDialogMessage message = new OpenDialogMessage(player.getId(), ((LivingEntity) livingEntity).getId(), res, scene.getStartingNode().getIdentifier());
+			AetherII.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> (Entity) livingEntity), message);
+		}*/
+	}
+
+	@Override
+	public void addListener(final IDialogChangeListener listener) {
+		this.listeners.add(listener);
+	}
+
+
+	@Override
+	public ResourceLocation getTalker() {
+		return this.talkableMob.getTalker();
+	}
+
+	public TalkableMob getTalkableMob() {
+		return talkableMob;
+	}
+
+	@Nullable
+	public Level getLevel() {
+		return level;
+	}
+
+	public void setLevel(Level level) {
+		this.level = level;
+	}
+
+	public ISceneInstance getSceneInstance() {
+		return sceneInstance;
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialog.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialog.java
@@ -1,0 +1,23 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface IDialog {
+	/**
+	 * The returned String represents an implementation that is used to draw
+	 * the {@link #getDialogData()} defined by this Dialog.
+	 *
+	 * @return An {@link Optional} object containing a String which represents
+	 * a renderer implementation
+	 */
+	Optional<String> getRenderer();
+
+	/**
+	 * Dialog data that will eventually be interpreted by this Dialog's
+	 * Renderer and drawn on screen.
+	 *
+	 * @return An {@link Optional} object containing a map of String data.
+	 */
+	Optional<Map<String, String>> getDialogData();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogAction.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogAction.java
@@ -1,0 +1,7 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import com.gildedgames.aetherii.api.TalkableController;
+
+public interface IDialogAction {
+	void performAction(TalkableController controller);
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogButton.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogButton.java
@@ -1,0 +1,41 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import net.minecraft.network.chat.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public interface IDialogButton {
+
+	/**
+	 * @return The conditions required for this button to display, but using or operation.
+	 */
+	@Nonnull
+	Collection<IDialogCondition> getOrConditions();
+
+	/**
+	 * @return The conditions required for this button to display.
+	 */
+	@Nonnull
+	Collection<IDialogCondition> getConditions();
+
+	/**
+	 * Returns the unlocalized label of this button.
+	 */
+	@Nonnull
+	String getLabel();
+
+	/**
+	 * Returns the localized display string of this button.
+	 *
+	 * @return
+	 */
+	@Nonnull
+	Component getLocalizedLabel();
+
+	/**
+	 * Returns the action to perform when this button is clicked.
+	 */
+	@Nonnull
+	Collection<IDialogAction> getActions();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogChangeListener.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogChangeListener.java
@@ -1,0 +1,13 @@
+package com.gildedgames.aetherii.api.dialog;
+
+public interface IDialogChangeListener {
+	/**
+	 * Called when the dialog controller advances or otherwise updates.
+	 */
+	void onDialogChanged();
+
+	/**
+	 * Called when the dialog controller closes a scene.
+	 */
+	void beforeSceneCloses();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogCondition.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogCondition.java
@@ -1,0 +1,10 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import com.gildedgames.aetherii.api.TalkableController;
+
+public interface IDialogCondition {
+	/**
+	 * Called when the condition needs to be met.
+	 */
+	boolean isMet(TalkableController controller);
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogLine.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogLine.java
@@ -1,0 +1,28 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+public interface IDialogLine {
+	/**
+	 * Returns the formatted body component of this line.
+	 *
+	 * @return The formatted body as a {@link Component}
+	 */
+	@Nonnull
+	Component getLocalizedBody();
+
+	/**
+	 * Returns the speaker of this line. If the result is empty, no speaker will be shown.
+	 * If the returned ResourceLocation has a #address suffix, it will use that to point to
+	 * a given slide registered within that speaker's json file.
+	 *
+	 * @return An {@link Optional} containing the {@link ResourceLocation} representing the speaker,
+	 * empty if there is no speaker.
+	 */
+	@Nonnull
+	Optional<ResourceLocation> getSpeaker();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogManager.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogManager.java
@@ -1,0 +1,15 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Optional;
+
+public interface IDialogManager {
+	Optional<IDialogTalker> getTalker(ResourceLocation resource);
+
+	Optional<IDialogScene> getScene(ResourceLocation resource);
+
+	Optional<IDialog> findDialog(String slideAddress, IDialogTalker speaker);
+
+	Optional<IDialogRenderer> findRenderer(String type);
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogNode.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogNode.java
@@ -1,0 +1,35 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+
+public interface IDialogNode {
+	/**
+	 * Returns the dialog lines of this node.
+	 */
+	@Nonnull
+	List<IDialogLine> getLines();
+
+	/**
+	 * Returns the buttons the player is given after all lines have been read.
+	 *
+	 * @return A collection of {@link IDialogButton}
+	 */
+	@Nonnull
+	Collection<IDialogButton> getButtons();
+
+	/**
+	 * Returns a collection of actions to perform after the node has been completed.
+	 *
+	 * @return A collection of {@link IDialogAction}
+	 */
+	@Nonnull
+	Collection<IDialogAction> getEndActions();
+
+	/**
+	 * This node's unique ID for use by other parts of the dialog system. Must be unique.
+	 */
+	@Nonnull
+	String getIdentifier();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogRenderer.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogRenderer.java
@@ -1,0 +1,21 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+public interface IDialogRenderer {
+	/**
+	 * Should ideally be used to interpret and transform slide data for the
+	 * {@link #draw(IDialog, PoseStack, double, double, int, int, float) draw()} method.
+	 *
+	 * @param slide The slide that will be rendered by this implementation.
+	 */
+	void setup(IDialog slide);
+
+	/**
+	 * Should interpret the data defined by the provided slide and
+	 * render it based on this implementation's goals.
+	 *
+	 * @param slide The slide that will be rendered by this implementation.
+	 */
+	void draw(IDialog slide, PoseStack poseStack, double screenWidth, double screenHeight, int mouseX, int mouseY, float partialTicks);
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogScene.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogScene.java
@@ -1,0 +1,29 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+public interface IDialogScene {
+	/**
+	 * Returns a dialog node for the scene.
+	 *
+	 * @param id The name of the node
+	 * @return An {@link Optional} value containing the node, if it exists
+	 */
+	Optional<IDialogNode> getNode(String id);
+
+	/**
+	 * Returns the starting node for this scene.
+	 *
+	 * @return A {@link IDialogNode} that kicks off the scene.
+	 */
+	@Nonnull
+	IDialogNode getStartingNode();
+
+	/**
+	 * Sets the starting node for this scene.
+	 *
+	 * @param id The name of the node
+	 */
+	void setStartingNode(String id);
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogTalker.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/IDialogTalker.java
@@ -1,0 +1,15 @@
+package com.gildedgames.aetherii.api.dialog;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Optional;
+
+public interface IDialogTalker {
+	/**
+	 * @return The name of the speaker.
+	 */
+	@Nonnull
+	String getUnlocalizedName();
+
+	Optional<Map<String, IDialog>> getDialogs();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/dialog/scene/ISceneInstance.java
+++ b/src/main/java/com/gildedgames/aetherii/api/dialog/scene/ISceneInstance.java
@@ -1,0 +1,19 @@
+package com.gildedgames.aetherii.api.dialog.scene;
+
+import com.gildedgames.aetherii.api.dialog.IDialogLine;
+import com.gildedgames.aetherii.api.dialog.IDialogNode;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+
+public interface ISceneInstance {
+	IDialogScene getScene();
+
+	IDialogNode getNode();
+
+	IDialogLine getLine();
+
+	void navigate(String nodeId);
+
+	void forwards();
+
+	boolean isDoneReading();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/entity/NormalTalker.java
+++ b/src/main/java/com/gildedgames/aetherii/api/entity/NormalTalker.java
@@ -1,0 +1,17 @@
+package com.gildedgames.aetherii.api.entity;
+
+import com.gildedgames.aetherii.api.dialog.IDialogChangeListener;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+import com.gildedgames.aetherii.api.dialog.scene.ISceneInstance;
+import net.minecraft.resources.ResourceLocation;
+
+public interface NormalTalker {
+	IDialogScene getCurrentScene();
+
+	ISceneInstance getCurrentSceneInstance();
+
+
+	void addListener(IDialogChangeListener listener);
+
+	ResourceLocation getTalker();
+}

--- a/src/main/java/com/gildedgames/aetherii/api/entity/TalkableMob.java
+++ b/src/main/java/com/gildedgames/aetherii/api/entity/TalkableMob.java
@@ -1,0 +1,19 @@
+package com.gildedgames.aetherii.api.entity;
+
+import com.gildedgames.aetherii.api.TalkableController;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TalkableMob {
+
+	ResourceLocation getTalker();
+
+	TalkableController getTalkableController();
+
+	void setTalkingEntity(Player player);
+
+	Optional<UUID> getTalkingUUID();
+}

--- a/src/main/java/com/gildedgames/aetherii/client/AetherClient.java
+++ b/src/main/java/com/gildedgames/aetherii/client/AetherClient.java
@@ -1,0 +1,23 @@
+package com.gildedgames.aetherii.client;
+
+import com.gildedgames.aetherii.AetherII;
+import com.gildedgames.aetherii.client.render.TestRenderer;
+import com.gildedgames.aetherii.register.ContentRegistry;
+import com.gildedgames.aetherii.register.ModEntities;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+
+@Mod.EventBusSubscriber(modid = AetherII.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class AetherClient {
+	@SubscribeEvent
+	public static void registerEntityRenders(EntityRenderersEvent.RegisterRenderers event) {
+		event.registerEntityRenderer(ModEntities.TEST.get(), TestRenderer::new);
+	}
+
+	public static void setup(FMLCommonSetupEvent event) {
+		ContentRegistry.getDialogManager().attachReloadListener();
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/client/render/TestRenderer.java
+++ b/src/main/java/com/gildedgames/aetherii/client/render/TestRenderer.java
@@ -1,0 +1,17 @@
+package com.gildedgames.aetherii.client.render;
+
+import com.gildedgames.aetherii.entity.TestEntity;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+
+public class TestRenderer<T extends TestEntity> extends EntityRenderer<T> {
+	public TestRenderer(EntityRendererProvider.Context pContext) {
+		super(pContext);
+	}
+
+	@Override
+	public ResourceLocation getTextureLocation(T pEntity) {
+		return null;
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/client/screen/DialogScreen.java
+++ b/src/main/java/com/gildedgames/aetherii/client/screen/DialogScreen.java
@@ -1,0 +1,205 @@
+package com.gildedgames.aetherii.client.screen;
+
+import com.gildedgames.aetherii.api.TalkableController;
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.api.dialog.IDialogButton;
+import com.gildedgames.aetherii.api.dialog.IDialogChangeListener;
+import com.gildedgames.aetherii.api.dialog.IDialogLine;
+import com.gildedgames.aetherii.api.dialog.IDialogNode;
+import com.gildedgames.aetherii.api.dialog.IDialogRenderer;
+import com.gildedgames.aetherii.api.dialog.IDialogTalker;
+import com.gildedgames.aetherii.api.dialog.scene.ISceneInstance;
+import com.gildedgames.aetherii.api.entity.TalkableMob;
+import com.gildedgames.aetherii.client.screen.button.DialogButton;
+import com.gildedgames.aetherii.register.ContentRegistry;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.GameNarrator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class DialogScreen extends Screen implements IDialogChangeListener {
+	public static boolean preventDialogControllerClose;
+
+	private final TalkableController controller;
+
+	private double nextArrowAnim, prevTime;
+
+	private boolean canApplyNextAction = true;
+
+	private IDialogNode node;
+
+	private IDialogTalker talker;
+
+	private IDialog dialog;
+
+	private IDialogRenderer renderer;
+
+
+	private ISceneInstance sceneInstance;
+
+	private ResourceLocation talkerTexture;
+
+	public DialogScreen(Player player, TalkableMob living) {
+		super(GameNarrator.NO_TITLE);
+
+		this.controller = living.getTalkableController();
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+		this.onDialogChanged();
+	}
+
+
+	@Override
+	public void render(PoseStack poseStack, int p_96563_, int p_96564_, float p_96565_) {
+		this.renderBackground(poseStack);
+		int baseBoxSize = 350;
+		final boolean resize = this.width - 40 > baseBoxSize;
+
+		if (!resize) {
+			baseBoxSize = this.width - 40;
+		}
+
+		if (this.dialog != null && this.renderer != null) {
+			this.renderer.draw(this.dialog, poseStack, this.width, this.height, p_96563_, p_96564_, p_96565_);
+		}
+
+		final String name = I18n.get(this.talker.getUnlocalizedName());
+
+		final Component textComponent = Component.translatable(name);
+
+		this.font.draw(poseStack, textComponent, resize ? (this.width / 2) - (baseBoxSize / 2) : 20,
+				this.height - (107), 0xFAEB95);
+
+		final IDialogLine line = this.controller.getCurrentLine();
+
+
+		final Component textComponent2 = Component.translatable(line.getLocalizedBody().getString(), Minecraft.getInstance().getUser().getName());
+
+		this.font.draw(poseStack, textComponent2, resize ? (this.width / 2) - (baseBoxSize / 2) : 20, this.height - 85, 0xFFFFFF);
+
+		super.render(poseStack, p_96563_, p_96564_, p_96565_);
+	}
+
+
+	@Override
+	public void onDialogChanged() {
+		this.buildGui(this.controller.getSceneInstance().getNode());
+	}
+
+	@Override
+	public void beforeSceneCloses() {
+
+	}
+
+	private void buildGui(final IDialogNode node) {
+		if (this.node != node) {
+			this.canApplyNextAction = false;
+		}
+
+		this.node = node;
+
+		this.resetGui();
+
+		final Collection<IDialogButton> beforeConditionButtons = node.getButtons();
+
+		int baseBoxSize = 350;
+		final boolean resize = this.width - 40 > baseBoxSize;
+
+		if (!resize) {
+			baseBoxSize = this.width - 40;
+		}
+
+		if (this.controller.isNodeFinished()) {
+			int index = 0;
+
+			for (final IDialogButton btn : beforeConditionButtons) {
+				if (this.controller.conditionsMet(btn)) {
+					Button button = new DialogButton((this.width / 2) - (baseBoxSize / 2), this.height - 65 + (index * 20), 200, 20, btn, (button2) -> {
+						this.controller.activateButton(btn);
+					});
+
+					this.addRenderableWidget(button);
+					button.visible = true;
+
+					index++;
+				}
+			}
+		}
+
+		/*if (this.controller.isNodeFinished() && this.controller.getCurrentNode().getButtons().size() > 0)
+		{
+			this.topTextBox.setText(line.getLocalizedBody());
+		}
+		else
+		{
+			this.bottomTextBox.setText(line.getLocalizedBody());
+		}*/
+
+		if (this.controller.getCurrentLine().getSpeaker().isPresent()) {
+			final ResourceLocation talkerPath = this.controller.getCurrentLine().getSpeaker().get();
+
+			this.talker = ContentRegistry.getDialogManager().getTalker(talkerPath).orElseThrow(() ->
+					new IllegalArgumentException("Couldn't getByte talker: " + talkerPath));
+
+			final String address;
+
+			// Check if the talker resourcelocation has a dialog address
+			if (talkerPath.getPath().contains("_")) {
+				// Obtain the dialog address from the Speaker resourcelocation
+				address = talkerPath.getPath().substring(talkerPath.getPath().indexOf("_") + 1);
+
+				this.dialog = ContentRegistry.getDialogManager().findDialog(address, this.talker).orElseThrow(() ->
+						new IllegalArgumentException("Couldn't find dialog: " + address));
+			} else if (this.talker.getDialogs().isPresent()) {
+				final Map<String, IDialog> dialogs = this.talker.getDialogs().get();
+
+				if (!dialogs.isEmpty() && dialogs.containsKey("default")) {
+					this.dialog = dialogs.get("default");
+				}
+			}
+
+			if (this.dialog != null && this.dialog.getRenderer().isPresent()) {
+				final String renderType = this.dialog.getRenderer().get();
+
+				this.renderer = ContentRegistry.getDialogManager().findRenderer(renderType).orElseThrow(() ->
+						new IllegalArgumentException("Couldn't find dialog renderer: " + renderType));
+
+				this.renderer.setup(this.dialog);
+			}
+
+			final boolean topText = this.controller.isNodeFinished() && this.controller.getCurrentNode().getButtons().size() > 0;
+
+
+		}
+	}
+
+	private void resetGui() {
+		this.clearWidgets();
+	}
+
+	private void nextAction() {
+		if (!this.canApplyNextAction) {
+			this.canApplyNextAction = true;
+
+			return;
+		}
+
+		this.controller.advance();
+	}
+
+	@Override
+	public boolean isPauseScreen() {
+		return false;
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/client/screen/button/DialogButton.java
+++ b/src/main/java/com/gildedgames/aetherii/client/screen/button/DialogButton.java
@@ -1,0 +1,30 @@
+package com.gildedgames.aetherii.client.screen.button;
+
+import com.gildedgames.aetherii.api.dialog.IDialogButton;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.network.chat.Component;
+
+public class DialogButton extends Button {
+	private final IDialogButton buttonData;
+
+	public DialogButton(int x, int y, int width, int height, IDialogButton buttonData, OnPress onPress) {
+		super(x, y, width, height, buttonData.getLocalizedLabel(), onPress);
+
+		this.buttonData = buttonData;
+	}
+
+	public IDialogButton getButtonData() {
+		return this.buttonData;
+	}
+
+	@Override
+	public Component getMessage() {
+		return this.buttonData.getLocalizedLabel();
+	}
+
+	@Override
+	public void renderButton(PoseStack p_93746_, int p_93747_, int p_93748_, float p_93749_) {
+		super.renderButton(p_93746_, p_93747_, p_93748_, p_93749_);
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/Dialog.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/Dialog.java
@@ -1,0 +1,25 @@
+package com.gildedgames.aetherii.dialog;
+
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class Dialog implements IDialog {
+	@SerializedName("render")
+	private String render;
+
+	@SerializedName("data")
+	private Map<String, String> dialogData;
+
+	@Override
+	public Optional<String> getRenderer() {
+		return this.render != null ? Optional.of(this.render) : Optional.empty();
+	}
+
+	@Override
+	public Optional<Map<String, String>> getDialogData() {
+		return this.dialogData != null ? Optional.of(this.dialogData) : Optional.empty();
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/DialogManager.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/DialogManager.java
@@ -1,0 +1,203 @@
+package com.gildedgames.aetherii.dialog;
+
+import com.gildedgames.aetherii.AetherII;
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.gildedgames.aetherii.api.dialog.IDialogCondition;
+import com.gildedgames.aetherii.api.dialog.IDialogManager;
+import com.gildedgames.aetherii.api.dialog.IDialogRenderer;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+import com.gildedgames.aetherii.api.dialog.IDialogTalker;
+import com.gildedgames.aetherii.dialog.data.DialogActionDeserializer;
+import com.gildedgames.aetherii.dialog.data.DialogConditionDeserializer;
+import com.gildedgames.aetherii.dialog.data.DialogDeserializer;
+import com.gildedgames.aetherii.dialog.data.DialogRendererDeserializer;
+import com.gildedgames.aetherii.dialog.data.actions.DialogActionExit;
+import com.gildedgames.aetherii.dialog.data.render.DialogRendererNOOP;
+import com.gildedgames.aetherii.dialog.data.render.DialogRendererStatic;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ReloadableResourceManager;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Optional;
+
+public class DialogManager implements IDialogManager {
+	private final HashMap<ResourceLocation, IDialogScene> cachedScenes = new HashMap<>();
+	private final HashMap<ResourceLocation, IDialogTalker> cachedTalkers = new HashMap<>();
+	private final HashMap<String, IDialogRenderer> registeredRenders = new HashMap<>();
+
+
+	private final Gson gson;
+	private final boolean allowCaching;
+
+
+	public DialogManager(final boolean allowCaching) {
+		this.allowCaching = allowCaching;
+
+		this.gson = this.buildDeserializer().create();
+		this.registerRenders();
+	}
+
+	private GsonBuilder buildDeserializer() {
+		final GsonBuilder builder = new GsonBuilder();
+
+		builder.registerTypeAdapter(IDialogAction.class, new DialogActionDeserializer());
+		builder.registerTypeAdapter(IDialogCondition.class, new DialogConditionDeserializer());
+
+		builder.registerTypeAdapter(DialogActionExit.class, new DialogActionExit.Deserializer());
+
+		builder.registerTypeAdapter(IDialogRenderer.class, new DialogRendererDeserializer());
+		builder.registerTypeAdapter(DialogRendererStatic.class, new DialogRendererStatic.Deserializer());
+		builder.registerTypeAdapter(DialogRendererNOOP.class, new DialogRendererNOOP.Deserializer());
+		builder.registerTypeAdapter(IDialog.class, new DialogDeserializer());
+		return builder;
+	}
+
+	protected void registerRenders() {
+		this.registeredRenders.put("static", new DialogRendererStatic());
+		this.registeredRenders.put("noop", new DialogRendererNOOP());
+	}
+
+	@Override
+	public Optional<IDialogTalker> getTalker(final ResourceLocation resource) {
+		if (this.allowCaching && this.cachedTalkers.containsKey(resource)) {
+			return Optional.of(this.cachedTalkers.get(resource));
+		}
+
+		final IDialogTalker talker;
+
+		try {
+			talker = this.loadTalker(resource);
+
+			if (this.allowCaching) {
+				this.cachedTalkers.put(resource, talker);
+			}
+		} catch (final IOException e) {
+			AetherII.LOGGER.error("Failed to load dialog talker: {}", resource, e);
+
+			return Optional.empty();
+		}
+
+		return Optional.of(talker);
+	}
+
+	@Override
+	public Optional<IDialogScene> getScene(final ResourceLocation resource) {
+		if (this.allowCaching && this.cachedScenes.containsKey(resource)) {
+			return Optional.of(this.cachedScenes.get(resource));
+		}
+
+		final IDialogScene scene;
+
+		try {
+			scene = this.loadScene(resource);
+
+			if (this.allowCaching) {
+				this.cachedScenes.put(resource, scene);
+			}
+		} catch (final IOException e) {
+			AetherII.LOGGER.error("Failed to load dialog scene: {}", resource, e);
+
+			return Optional.empty();
+		}
+
+		return Optional.of(scene);
+	}
+
+
+	public IDialogTalker loadTalker(ResourceLocation resource) throws IOException {
+		final String path = resource.getPath();
+		String pathWithoutSlide = path;
+
+		if (path.contains("_")) {
+			pathWithoutSlide = path.replace(path.substring(path.indexOf("_")), "");
+		}
+
+		final String talkerPath = "dialog/talkers/" + pathWithoutSlide + ".json";
+
+		AetherII.LOGGER.info("Loading dialog talker from file {}", resource.getNamespace() + ":" + talkerPath);
+
+		Optional<Resource> rawResource = Minecraft.getInstance().getResourceManager().getResource(new ResourceLocation(resource.getNamespace(), talkerPath));
+
+		if (rawResource.isEmpty()) {
+			throw new IllegalArgumentException("Couldn't get talker: " + resource.getNamespace() + ":" + talkerPath);
+		}
+
+		InputStream inputstream = rawResource.get().open();
+
+		try (InputStreamReader reader = new InputStreamReader(inputstream, StandardCharsets.UTF_8)) {
+			return this.gson.fromJson(reader, DialogTalker.class);
+		}
+	}
+
+	private IDialogScene loadScene(final ResourceLocation resource) throws IOException {
+		final String path = "dialog/" + resource.getPath() + ".json";
+
+		AetherII.LOGGER.info("Loading dialog scene from file {}", resource.getNamespace() + ":" + path);
+
+		Optional<Resource> rawResource = Minecraft.getInstance().getResourceManager().getResource(new ResourceLocation(resource.getNamespace(), path));
+
+		if (rawResource.isEmpty()) {
+			throw new IllegalArgumentException("Couldn't get Scene: " + resource.getNamespace() + ":" + path);
+		}
+
+		InputStream inputstream = rawResource.get().open();
+
+		try (InputStreamReader reader = new InputStreamReader(inputstream, StandardCharsets.UTF_8)) {
+			return this.gson.fromJson(reader, DialogSchema.class);
+		}
+	}
+
+	@Override
+	public Optional<IDialog> findDialog(final String slideAddress, final IDialogTalker speaker) {
+		if (speaker == null || slideAddress == null || !speaker.getDialogs().isPresent() || !speaker.getDialogs().get().containsKey(slideAddress)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(speaker.getDialogs().get().get(slideAddress));
+	}
+
+	@Override
+	public Optional<IDialogRenderer> findRenderer(final String type) {
+		if (type == null || !this.registeredRenders.containsKey(type)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(this.registeredRenders.get(type));
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	public void attachReloadListener() {
+		final ResourceManager resManager = Minecraft.getInstance().getResourceManager();
+
+		if (resManager instanceof ReloadableResourceManager) {
+			((ReloadableResourceManager) resManager).registerReloadListener(new ReloadListener(this));
+		}
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	public static class ReloadListener implements ResourceManagerReloadListener {
+		private final DialogManager manager;
+
+		public ReloadListener(final DialogManager manager) {
+			this.manager = manager;
+		}
+
+		@Override
+		public void onResourceManagerReload(final ResourceManager resourceManager) {
+			this.manager.cachedScenes.clear();
+		}
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/DialogSchema.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/DialogSchema.java
@@ -1,0 +1,148 @@
+package com.gildedgames.aetherii.dialog;
+
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.gildedgames.aetherii.api.dialog.IDialogButton;
+import com.gildedgames.aetherii.api.dialog.IDialogCondition;
+import com.gildedgames.aetherii.api.dialog.IDialogLine;
+import com.gildedgames.aetherii.api.dialog.IDialogNode;
+import com.gildedgames.aetherii.api.dialog.IDialogScene;
+import com.google.gson.annotations.SerializedName;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class DialogSchema implements IDialogScene {
+	@SerializedName("nodes")
+	private Collection<DialogNodeSchema> nodes;
+
+	private String startingNodeId;
+
+	@Override
+	public Optional<IDialogNode> getNode(final String id) {
+		for (final DialogNodeSchema node : this.nodes) {
+			if (id.equals(node.getIdentifier())) {
+				return Optional.of(node);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	@Nonnull
+	@Override
+	public IDialogNode getStartingNode() {
+		return this.getNode(this.startingNodeId).orElseThrow(() ->
+				new IllegalArgumentException("Couldn't find starting node with id: '" + this.startingNodeId + "'"));
+	}
+
+	@Override
+	public void setStartingNode(String id) {
+		this.startingNodeId = id;
+	}
+
+	private class DialogNodeSchema implements IDialogNode {
+		@SerializedName("buttons")
+		private final List<DialogButtonSchema> buttons = null;
+
+		@SerializedName("end_actions")
+		private final Collection<IDialogAction> actions = null;
+
+		@SerializedName("name")
+		private String name;
+
+		@SerializedName("lines")
+		private List<DialogLineSchema> lines;
+
+		@Nonnull
+		@Override
+		public List<IDialogLine> getLines() {
+			return Collections.unmodifiableList(this.lines);
+		}
+
+		@Nonnull
+		@Override
+		public Collection<IDialogButton> getButtons() {
+			return this.buttons == null ? Collections.emptyList() : Collections.unmodifiableList(this.buttons);
+		}
+
+		@Nonnull
+		@Override
+		public Collection<IDialogAction> getEndActions() {
+			return this.actions == null ? Collections.emptyList() : Collections.unmodifiableCollection(this.actions);
+		}
+
+		@Nonnull
+		@Override
+		public String getIdentifier() {
+			return this.name;
+		}
+	}
+
+	private class DialogButtonSchema implements IDialogButton {
+		@SerializedName("orConditions")
+		private Collection<IDialogCondition> orConditions;
+
+		@SerializedName("conditions")
+		private Collection<IDialogCondition> conditions;
+
+		@SerializedName("label")
+		private String label;
+
+		@SerializedName("actions")
+		private Collection<IDialogAction> actions;
+
+		@Nonnull
+		@Override
+		public Collection<IDialogCondition> getOrConditions() {
+			return this.orConditions == null ? Collections.emptyList() : this.orConditions;
+		}
+
+		@Nonnull
+		@Override
+		public Collection<IDialogCondition> getConditions() {
+			return this.conditions == null ? Collections.emptyList() : this.conditions;
+		}
+
+		@Nonnull
+		@Override
+		public String getLabel() {
+			return this.label;
+		}
+
+		@Nonnull
+		@Override
+		public Component getLocalizedLabel() {
+			return Component.translatable(this.label);
+		}
+
+		@Nonnull
+		@Override
+		public Collection<IDialogAction> getActions() {
+			return this.actions;
+		}
+	}
+
+	private class DialogLineSchema implements IDialogLine {
+		@SerializedName("talker")
+		private final String talker = null;
+
+		@SerializedName("text")
+		private String text;
+
+		@Override
+		public Component getLocalizedBody() {
+			return Component.translatable(this.text);
+		}
+
+		@Override
+		public Optional<ResourceLocation> getSpeaker() {
+			return this.talker != null ? Optional.of(new ResourceLocation(this.talker)) : Optional.empty();
+		}
+
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/DialogTalker.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/DialogTalker.java
@@ -1,0 +1,28 @@
+package com.gildedgames.aetherii.dialog;
+
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.api.dialog.IDialogTalker;
+import com.google.gson.annotations.SerializedName;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Optional;
+
+public class DialogTalker implements IDialogTalker {
+	@SerializedName("name")
+	private String name;
+
+	@SerializedName("dialogs")
+	private Map<String, IDialog> dialogs;
+
+	@Nonnull
+	@Override
+	public String getUnlocalizedName() {
+		return this.name != null ? this.name : "";
+	}
+
+	@Override
+	public Optional<Map<String, IDialog>> getDialogs() {
+		return this.dialogs != null ? Optional.of(this.dialogs) : Optional.empty();
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/DialogActionDeserializer.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/DialogActionDeserializer.java
@@ -1,0 +1,37 @@
+package com.gildedgames.aetherii.dialog.data;
+
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.gildedgames.aetherii.dialog.data.actions.DialogActionExit;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+public class DialogActionDeserializer implements JsonDeserializer<IDialogAction> {
+	private final HashMap<String, Class<? extends IDialogAction>> actions = new HashMap<>();
+
+	public DialogActionDeserializer() {
+		this.actions.put("exit", DialogActionExit.class);
+	}
+
+	@Override
+	public IDialogAction deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
+		final JsonObject root = json.getAsJsonObject();
+
+		if (!root.has("type")) {
+			throw new JsonParseException("Missing required field 'type' for action");
+		}
+
+		final String type = root.get("type").getAsString();
+
+		if (!this.actions.containsKey(type)) {
+			throw new JsonParseException("Invalid action type " + type);
+		}
+
+		return context.deserialize(json, this.actions.get(type));
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/DialogConditionDeserializer.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/DialogConditionDeserializer.java
@@ -1,0 +1,35 @@
+package com.gildedgames.aetherii.dialog.data;
+
+import com.gildedgames.aetherii.api.dialog.IDialogCondition;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+public class DialogConditionDeserializer implements JsonDeserializer<IDialogCondition> {
+	private final HashMap<String, Class<? extends IDialogCondition>> conditions = new HashMap<>();
+
+	public DialogConditionDeserializer() {
+	}
+
+	@Override
+	public IDialogCondition deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
+		final JsonObject root = json.getAsJsonObject();
+
+		if (!root.has("type")) {
+			throw new JsonParseException("Missing required field 'type' for action");
+		}
+
+		final String type = root.get("type").getAsString();
+
+		if (!this.conditions.containsKey(type)) {
+			throw new JsonParseException("Invalid action type " + type);
+		}
+
+		return context.deserialize(json, this.conditions.get(type));
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/DialogDeserializer.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/DialogDeserializer.java
@@ -1,0 +1,17 @@
+package com.gildedgames.aetherii.dialog.data;
+
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.dialog.Dialog;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public class DialogDeserializer implements JsonDeserializer<IDialog> {
+	@Override
+	public IDialog deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		return context.deserialize(json, Dialog.class);
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/DialogRendererDeserializer.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/DialogRendererDeserializer.java
@@ -1,0 +1,37 @@
+package com.gildedgames.aetherii.dialog.data;
+
+import com.gildedgames.aetherii.api.dialog.IDialogRenderer;
+import com.gildedgames.aetherii.dialog.data.render.DialogRendererStatic;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+public class DialogRendererDeserializer implements JsonDeserializer<IDialogRenderer> {
+	private final HashMap<String, Class<? extends IDialogRenderer>> renderers = new HashMap<>();
+
+	public DialogRendererDeserializer() {
+		this.renderers.put("static", DialogRendererStatic.class);
+	}
+
+	@Override
+	public IDialogRenderer deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		JsonObject root = json.getAsJsonObject();
+
+		if (!root.has("type")) {
+			throw new JsonParseException("Missing required field 'type' for action");
+		}
+
+		String type = root.get("type").getAsString();
+
+		if (!this.renderers.containsKey(type)) {
+			throw new JsonParseException("Invalid action type " + type);
+		}
+
+		return context.deserialize(json, this.renderers.get(type));
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/actions/DialogActionExit.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/actions/DialogActionExit.java
@@ -1,0 +1,28 @@
+package com.gildedgames.aetherii.dialog.data.actions;
+
+import com.gildedgames.aetherii.api.TalkableController;
+import com.gildedgames.aetherii.api.dialog.IDialogAction;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import net.minecraft.client.Minecraft;
+
+import java.lang.reflect.Type;
+
+public class DialogActionExit implements IDialogAction {
+	private DialogActionExit() {
+	}
+
+	@Override
+	public void performAction(TalkableController controller) {
+		Minecraft.getInstance().setScreen(null);
+	}
+
+	public static class Deserializer implements JsonDeserializer<DialogActionExit> {
+		@Override
+		public DialogActionExit deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+			return new DialogActionExit();
+		}
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/render/DialogRendererNOOP.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/render/DialogRendererNOOP.java
@@ -1,0 +1,29 @@
+package com.gildedgames.aetherii.dialog.data.render;
+
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.api.dialog.IDialogRenderer;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import java.lang.reflect.Type;
+
+public class DialogRendererNOOP implements IDialogRenderer {
+
+	@Override
+	public void setup(IDialog slide) {
+	}
+
+	@Override
+	public void draw(IDialog slide, PoseStack poseStack, double screenWidth, double screenHeight, int mouseX, int mouseY, float partialTicks) {
+	}
+
+	public static class Deserializer implements JsonDeserializer<DialogRendererNOOP> {
+		@Override
+		public DialogRendererNOOP deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+			return new DialogRendererNOOP();
+		}
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/dialog/data/render/DialogRendererStatic.java
+++ b/src/main/java/com/gildedgames/aetherii/dialog/data/render/DialogRendererStatic.java
@@ -1,0 +1,75 @@
+package com.gildedgames.aetherii.dialog.data.render;
+
+import com.gildedgames.aetherii.api.dialog.IDialog;
+import com.gildedgames.aetherii.api.dialog.IDialogRenderer;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.resources.ResourceLocation;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class DialogRendererStatic implements IDialogRenderer {
+	private ResourceLocation slideTexture;
+
+	private float scale = 1.0F;
+
+	private int width, height;
+
+	@Override
+	public void setup(IDialog slide) {
+		if (!slide.getDialogData().isPresent()) {
+			return;
+		}
+
+		Map<String, String> data = slide.getDialogData().get();
+
+		if (data.containsKey("resource")) {
+			this.slideTexture = new ResourceLocation(data.get("resource"));
+		}
+
+		if (data.containsKey("scale")) {
+			this.scale = Float.valueOf(data.get("scale"));
+		}
+
+		if (data.containsKey("width")) {
+			this.width = Integer.valueOf(data.get("width"));
+		}
+
+		if (data.containsKey("height")) {
+			this.height = Integer.valueOf(data.get("height"));
+		}
+	}
+
+	@Override
+	public void draw(IDialog slide, PoseStack poseStack, double screenWidth, double screenHeight, int mouseX, int mouseY, float partialTicks) {
+		if (this.slideTexture == null) {
+			return;
+		}
+		double scaledWidth = this.width * this.scale;
+		double scaledHeight = this.height * this.scale;
+
+		poseStack.pushPose();
+
+		poseStack.translate((screenWidth / 2) - (scaledWidth / 2), screenHeight - 90 - scaledHeight, 0);
+		poseStack.scale(this.scale, this.scale, this.scale);
+
+		RenderSystem.setShaderTexture(0, this.slideTexture);
+		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+		Gui.blit(poseStack, 0, 0, 0, 0, this.width, this.height, this.width, this.height);
+		poseStack.popPose();
+	}
+
+	public static class Deserializer implements JsonDeserializer<DialogRendererStatic> {
+		@Override
+		public DialogRendererStatic deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+			return new DialogRendererStatic();
+		}
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/entity/TestEntity.java
+++ b/src/main/java/com/gildedgames/aetherii/entity/TestEntity.java
@@ -1,0 +1,93 @@
+package com.gildedgames.aetherii.entity;
+
+import com.gildedgames.aetherii.AetherII;
+import com.gildedgames.aetherii.api.TalkableController;
+import com.gildedgames.aetherii.api.entity.TalkableMob;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.goal.FloatGoal;
+import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
+import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.gameevent.GameEvent;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class TestEntity extends PathfinderMob implements TalkableMob {
+	private static final EntityDataAccessor<Optional<UUID>> DATA_TALKED_FLAGS_ID = SynchedEntityData.defineId(TestEntity.class, EntityDataSerializers.OPTIONAL_UUID);
+	private final TalkableController talkableController;
+
+	public TestEntity(EntityType<? extends TestEntity> p_21683_, Level p_21684_) {
+		super(p_21683_, p_21684_);
+		this.talkableController = new TalkableController(this);
+		this.talkableController.setLevel(level);
+	}
+
+	@Override
+	protected void defineSynchedData() {
+		super.defineSynchedData();
+		this.entityData.define(DATA_TALKED_FLAGS_ID, Optional.empty());
+	}
+
+	public static AttributeSupplier.Builder createAttributes() {
+		return Mob.createMobAttributes();
+	}
+
+	@Override
+	public InteractionResult mobInteract(Player p_27584_, InteractionHand p_27585_) {
+		ItemStack itemstack = p_27584_.getItemInHand(p_27585_);
+		boolean flag = super.mobInteract(p_27584_, p_27585_) == InteractionResult.PASS;
+		if (flag) {
+			this.setTalkingEntity(p_27584_);
+			String node = "start";
+
+			this.getTalkableController().openScene(p_27584_, this, new ResourceLocation(AetherII.MODID, "test/new_comer"), node);
+
+			this.gameEvent(GameEvent.ENTITY_INTERACT, this);
+
+			return InteractionResult.SUCCESS;
+		}
+
+		return InteractionResult.FAIL;
+	}
+
+	@Override
+	protected void registerGoals() {
+		super.registerGoals();
+		this.goalSelector.addGoal(0, new FloatGoal(this));
+		//this.goalSelector.addGoal(5, new RandomStrollGoal(this, 1.0D));
+		this.goalSelector.addGoal(6, new LookAtPlayerGoal(this, Player.class, 8.0F));
+		this.goalSelector.addGoal(7, new RandomLookAroundGoal(this));
+	}
+
+	@Override
+	public ResourceLocation getTalker() {
+		return new ResourceLocation(AetherII.MODID, "test");
+	}
+
+	@Override
+	public TalkableController getTalkableController() {
+		return talkableController;
+	}
+
+	@Override
+	public void setTalkingEntity(Player player) {
+		this.entityData.set(DATA_TALKED_FLAGS_ID, this.getTalkingUUID());
+	}
+
+	@Override
+	public Optional<UUID> getTalkingUUID() {
+		return this.entityData.get(DATA_TALKED_FLAGS_ID);
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/message/OpenDialogMessage.java
+++ b/src/main/java/com/gildedgames/aetherii/message/OpenDialogMessage.java
@@ -1,0 +1,63 @@
+package com.gildedgames.aetherii.message;
+
+import com.gildedgames.aetherii.api.entity.TalkableMob;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class OpenDialogMessage {
+
+	private int entityId;
+	private int ownerID;
+
+	private ResourceLocation name;
+
+	private String startingNodeId;
+
+
+	public OpenDialogMessage(int id, int ownerID, final ResourceLocation res, String startingNodeId) {
+		this.entityId = id;
+		this.ownerID = ownerID;
+		this.name = res;
+		this.startingNodeId = startingNodeId;
+	}
+
+
+	public void serialize(FriendlyByteBuf buffer) {
+		buffer.writeInt(this.entityId);
+		buffer.writeInt(this.ownerID);
+		buffer.writeResourceLocation(this.name);
+		buffer.writeUtf(this.startingNodeId);
+	}
+
+	public static OpenDialogMessage deserialize(FriendlyByteBuf buffer) {
+		int entityId = buffer.readInt();
+		int ownerId = buffer.readInt();
+		ResourceLocation name = buffer.readResourceLocation();
+		String nodeId = buffer.readUtf();
+		return new OpenDialogMessage(entityId, ownerId, name, nodeId);
+	}
+
+	public static boolean handle(OpenDialogMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+		NetworkEvent.Context context = contextSupplier.get();
+
+		if (context.getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+			context.enqueueWork(() -> {
+				Entity entity = Minecraft.getInstance().player.level.getEntity(message.entityId);
+				Entity ownerEntity = Minecraft.getInstance().player.level.getEntity(message.ownerID);
+				if (entity != null && entity instanceof Player && ownerEntity != null && ownerEntity instanceof TalkableMob) {
+					//((TalkableMob) ownerEntity).getTalkableController().setConditionsMetData(message.conditionsMet);
+					((TalkableMob) ownerEntity).getTalkableController().openScene(((Player) entity), (TalkableMob) ownerEntity, message.name, message.startingNodeId);
+				}
+			});
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/register/ContentRegistry.java
+++ b/src/main/java/com/gildedgames/aetherii/register/ContentRegistry.java
@@ -1,0 +1,15 @@
+package com.gildedgames.aetherii.register;
+
+import com.gildedgames.aetherii.dialog.DialogManager;
+
+public class ContentRegistry {
+	private static final DialogManager dialogManager = new DialogManager(true);
+
+	public static void preInit() {
+
+	}
+
+	public static DialogManager getDialogManager() {
+		return dialogManager;
+	}
+}

--- a/src/main/java/com/gildedgames/aetherii/register/ModEntities.java
+++ b/src/main/java/com/gildedgames/aetherii/register/ModEntities.java
@@ -1,0 +1,25 @@
+package com.gildedgames.aetherii.register;
+
+import com.gildedgames.aetherii.AetherII;
+import com.gildedgames.aetherii.entity.TestEntity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = AetherII.MODID)
+public class ModEntities {
+	public static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES, AetherII.MODID);
+
+	public static final RegistryObject<EntityType<TestEntity>> TEST = ENTITIES.register("test", () -> EntityType.Builder.of(TestEntity::new, MobCategory.CREATURE)
+			.sized(0.6F, 1.85F).clientTrackingRange(10).build("aether:test"));
+
+	@SubscribeEvent
+	public static void registerEntityAttribute(EntityAttributeCreationEvent event) {
+		event.put(TEST.get(), TestEntity.createAttributes().build());
+	}
+}

--- a/src/main/resources/assets/aether_ii/dialog/talkers/test.json
+++ b/src/main/resources/assets/aether_ii/dialog/talkers/test.json
@@ -1,0 +1,14 @@
+{
+  "name": "entity.aether_ii.test",
+  "dialogs": {
+    "default": {
+      "render": "static",
+      "data": {
+        "resource": "aether_ii:textures/dialog/test.png",
+        "scale": "1.6",
+        "width": "110",
+        "height": "98"
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/aether_ii/dialog/test/new_comer.json
+++ b/src/main/resources/assets/aether_ii/dialog/test/new_comer.json
@@ -1,0 +1,23 @@
+{
+  "nodes": [
+    {
+      "name": "start",
+      "lines": [
+        {
+          "talker": "aether_ii:test",
+          "text": "test.greet.start_not_introduced"
+        }
+      ],
+      "buttons": [
+        {
+          "label": "generic.goodbye",
+          "actions": [
+            {
+              "type": "exit"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/assets/aether_ii/lang/en_us.json
+++ b/src/main/resources/assets/aether_ii/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "test.greet.start_not_introduced": "oh hi. %1$s",
+  "generic.goodbye": "see ya"
+}

--- a/src/main/resources/assets/aether_ii/lang/ja_jp.json
+++ b/src/main/resources/assets/aether_ii/lang/ja_jp.json
@@ -1,0 +1,4 @@
+{
+  "test.greet.start_not_introduced": "あら、こんにちは %1$s",
+  "generic.goodbye": "じゃあね"
+}


### PR DESCRIPTION
This is a old aether dialog system port for 1.19(basically Rewrote moemob's code from aether for aether)

```
ChangeLog:
Implements aether dialog system
And some Example Entity(You should remove it)
```

I agree to the Contributor License Agreement (CLA).
