### PR TITLE
feat: PerlinNoiseFunction for features and generation now properly uses the world's seed

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/mixin/mixins/common/RandomStateMixin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/mixins/common/RandomStateMixin.java
@@ -14,10 +14,8 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(RandomState.class)
 public class RandomStateMixin {
-
     @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/NoiseRouter;mapAll(Lnet/minecraft/world/level/levelgen/DensityFunction$Visitor;)Lnet/minecraft/world/level/levelgen/NoiseRouter;"))
     private NoiseRouter init(NoiseRouter instance, DensityFunction.Visitor visitor, Operation<NoiseRouter> original, NoiseGeneratorSettings settings, HolderGetter<NormalNoise.NoiseParameters> noiseParametersGetter, final long levelSeed) {
         return original.call(instance, visitor).mapAll(PerlinNoiseFunction.createOrGetVisitor(levelSeed));
     }
-
 }

--- a/src/main/java/com/aetherteam/aetherii/mixin/mixins/common/RandomStateMixin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/mixins/common/RandomStateMixin.java
@@ -1,0 +1,23 @@
+package com.aetherteam.aetherii.mixin.mixins.common;
+
+import com.aetherteam.aetherii.world.density.PerlinNoiseFunction;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraft.world.level.levelgen.NoiseRouter;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.synth.NormalNoise;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(RandomState.class)
+public class RandomStateMixin {
+
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/NoiseRouter;mapAll(Lnet/minecraft/world/level/levelgen/DensityFunction$Visitor;)Lnet/minecraft/world/level/levelgen/NoiseRouter;"))
+    private NoiseRouter init(NoiseRouter instance, DensityFunction.Visitor visitor, Operation<NoiseRouter> original, NoiseGeneratorSettings settings, HolderGetter<NormalNoise.NoiseParameters> noiseParametersGetter, final long levelSeed) {
+        return original.call(instance, visitor).mapAll(PerlinNoiseFunction.createOrGetVisitor(levelSeed));
+    }
+
+}

--- a/src/main/java/com/aetherteam/aetherii/world/density/PerlinNoiseFunction.java
+++ b/src/main/java/com/aetherteam/aetherii/world/density/PerlinNoiseFunction.java
@@ -4,54 +4,66 @@ import com.aetherteam.aetherii.mixin.mixins.common.accessor.PerlinNoiseAccessor;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.levelgen.DensityFunction;
 import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import net.minecraft.world.level.levelgen.synth.NormalNoise;
 import net.minecraft.world.level.levelgen.synth.PerlinNoise;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 public class PerlinNoiseFunction implements DensityFunction {
 
     public static final KeyDispatchDataCodec<PerlinNoiseFunction> CODEC = KeyDispatchDataCodec.of(RecordCodecBuilder.mapCodec(
-            instance -> instance.group(
+            p_208798_ -> p_208798_.group(
                             NormalNoise.NoiseParameters.DIRECT_CODEC.fieldOf("noise").forGetter((func) -> func.params),
                             Codec.DOUBLE.fieldOf("xz_scale").forGetter((func) -> func.xzScale),
                             Codec.DOUBLE.fieldOf("y_scale").forGetter((func) -> func.yScale),
                             Codec.LONG.fieldOf("seed").forGetter((func) -> func.seed)
                     )
-                    .apply(instance, PerlinNoiseFunction::new)));
+                    .apply(p_208798_, PerlinNoiseFunction::new)));
 
-    public final PerlinNoise noise;
+    @Nullable
+    public PerlinNoise noise = null;
+    private static final Map<Long, PerlinNoiseVisitor> VISITORS = new HashMap<>();
+    // This is used before the seed is initialized, for methods such as DensityFunction#maxValue
+    private final PerlinNoise fakeNoise;
     public final NormalNoise.NoiseParameters params;
     private final long seed;
     private final double xzScale;
     private final double yScale;
 
     public PerlinNoiseFunction(NormalNoise.NoiseParameters params, double xzScale, double yScale, long seed) {
-        this(PerlinNoise.create(new XoroshiroRandomSource(seed), params.firstOctave(), params.amplitudes()), params, xzScale, yScale, seed);
-    }
-
-    private PerlinNoiseFunction(PerlinNoise noise, NormalNoise.NoiseParameters params, double xzScale, double yScale, long seed) {
         this.seed = seed;
         this.params = params;
-        this.noise = noise;
         this.xzScale = xzScale;
         this.yScale = yScale;
+        this.fakeNoise = PerlinNoise.create(new XoroshiroRandomSource(seed), params.firstOctave(), params.amplitudes());
     }
 
-    public double compute(DensityFunction.FunctionContext context) {
-        return this.noise
-                .getValue((double)context.blockX() * this.xzScale, (double)context.blockY() * this.yScale, (double)context.blockZ() * this.xzScale);
+    public double compute(FunctionContext context) {
+        if (this.noise == null) {
+            throw new NullPointerException("PerlinNoiseFunction has not been initialized yet! Please initialize by running mapAll on this function or a parent function with a PerlinNoiseVisitor!");
+        } else {
+            return this.noise
+                    .getValue((double)context.blockX() * this.xzScale, (double)context.blockY() * this.yScale, (double)context.blockZ() * this.xzScale);
+        }
     }
 
     @Override
-    public void fillArray(double[] pArray, ContextProvider contextProvider) {
-        contextProvider.fillAllDirectly(pArray, this);
+    public void fillArray(double[] array, ContextProvider contextProvider) {
+        contextProvider.fillAllDirectly(array, this);
     }
 
     @Override
     public DensityFunction mapAll(Visitor visitor) {
-        return visitor.apply(new PerlinNoiseFunction(this.noise, this.params, this.xzScale, this.yScale, this.seed));
+        return visitor.apply(this);
     }
+
 
     @Override
     public double minValue() {
@@ -60,12 +72,44 @@ public class PerlinNoiseFunction implements DensityFunction {
 
     @Override
     public double maxValue() {
-        return ((PerlinNoiseAccessor)this.noise).callMaxValue();
+        if (this.noise != null) {
+            return ((PerlinNoiseAccessor)this.noise).callMaxValue();
+        } else {
+            return ((PerlinNoiseAccessor)this.fakeNoise).callMaxValue();
+        }
     }
 
+    public PerlinNoiseFunction initialize(Function<Long, RandomSource> rand) {
+        this.noise = PerlinNoise.create(rand.apply(this.seed), this.params.firstOctave(), this.params.amplitudes());
+        return this;
+    }
+
+    public static PerlinNoiseVisitor createOrGetVisitor(long seed) {
+        return VISITORS.computeIfAbsent(seed, l -> new PerlinNoiseVisitor(noise -> {
+            if (noise.initialized()) {
+                return noise;
+            } else {
+                return noise.initialize(offset -> new XoroshiroRandomSource(l + offset));
+            }
+        }));
+    }
+
+    public boolean initialized() {
+        return this.noise != null;
+    }
 
     @Override
     public KeyDispatchDataCodec<? extends DensityFunction> codec() {
         return CODEC;
+    }
+
+    public record PerlinNoiseVisitor(UnaryOperator<PerlinNoiseFunction> operator) implements DensityFunction.Visitor {
+        @Override
+        public DensityFunction apply(DensityFunction function) {
+            if (function instanceof PerlinNoiseFunction pnf) {
+                return operator.apply(pnf);
+            }
+            return function;
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aetherii/world/feature/CloudbedFeature.java
+++ b/src/main/java/com/aetherteam/aetherii/world/feature/CloudbedFeature.java
@@ -1,9 +1,11 @@
 package com.aetherteam.aetherii.world.feature;
 
+import com.aetherteam.aetherii.world.density.PerlinNoiseFunction;
 import com.aetherteam.aetherii.world.feature.configuration.CloudbedConfiguration;
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.levelgen.DensityFunction;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
@@ -17,9 +19,15 @@ public class CloudbedFeature extends Feature<CloudbedConfiguration> {
     @Override
     public boolean place(FeaturePlaceContext<CloudbedConfiguration> context) {
         CloudbedConfiguration config = context.config();
+        WorldGenLevel level = context.level();
 
         DensityFunction cloudNoise = config.cloudNoise();
         DensityFunction yOffsetNoise = config.yOffset();
+
+        DensityFunction.Visitor visitor = PerlinNoiseFunction.createOrGetVisitor(level.getSeed());
+
+        cloudNoise.mapAll(visitor);
+        yOffsetNoise.mapAll(visitor);
 
         // This should be placed, once per chunk
         int chunkX = context.origin().getX() - (context.origin().getX() % 16);

--- a/src/main/java/com/aetherteam/aetherii/world/feature/CoastFeature.java
+++ b/src/main/java/com/aetherteam/aetherii/world/feature/CoastFeature.java
@@ -2,6 +2,7 @@ package com.aetherteam.aetherii.world.feature;
 
 import com.aetherteam.aetherii.AetherIITags;
 import com.aetherteam.aetherii.data.resources.registries.features.AetherIIVegetationFeatures;
+import com.aetherteam.aetherii.world.density.PerlinNoiseFunction;
 import com.aetherteam.aetherii.world.feature.configuration.CoastConfiguration;
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
@@ -29,6 +30,11 @@ public class CoastFeature extends Feature<CoastConfiguration> {
         RandomSource random = context.random();
         BlockPos pos = context.origin();
         CoastConfiguration config = context.config();
+
+        DensityFunction.Visitor visitor = PerlinNoiseFunction.createOrGetVisitor(level.getSeed());
+
+        config.distanceNoise().mapAll(visitor);
+        config.patternNoise().ifPresent(noise -> noise.mapAll(visitor));
 
         for (int x = pos.getX(); x < pos.getX() + 16; ++x) {
             for (int z = pos.getZ(); z < pos.getZ() + 16; ++z) {

--- a/src/main/java/com/aetherteam/aetherii/world/feature/NoiseLakeFeature.java
+++ b/src/main/java/com/aetherteam/aetherii/world/feature/NoiseLakeFeature.java
@@ -3,6 +3,7 @@ package com.aetherteam.aetherii.world.feature;
 import com.aetherteam.aetherii.block.AetherIIBlocks;
 import com.aetherteam.aetherii.block.natural.RockBlock;
 import com.aetherteam.aetherii.block.natural.TwigBlock;
+import com.aetherteam.aetherii.world.density.PerlinNoiseFunction;
 import com.aetherteam.aetherii.world.feature.configuration.NoiseLakeConfiguration;
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
@@ -57,6 +58,12 @@ public class NoiseLakeFeature extends Feature<NoiseLakeConfiguration> {
         DensityFunction lakeNoise = config.lakeNoise();
         DensityFunction lakeFloorNoise = config.lakeFloorNoise();
         DensityFunction lakeBarrierNoise = config.lakeBarrierNoise();
+
+        DensityFunction.Visitor visitor = PerlinNoiseFunction.createOrGetVisitor(context.level().getSeed());
+
+        lakeNoise.mapAll(visitor);
+        lakeFloorNoise.mapAll(visitor);
+        lakeBarrierNoise.mapAll(visitor);
 
         double density = lakeNoise.compute(new DensityFunction.SinglePointContext(x, y, z));
         double floor = lakeFloorNoise.compute(new DensityFunction.SinglePointContext(x, y, z));

--- a/src/main/resources/aether_ii.mixins.json
+++ b/src/main/resources/aether_ii.mixins.json
@@ -10,6 +10,7 @@
     "common.ItemCooldownsMixin",
     "common.ItemStackMixin",
     "common.PlayerMixin",
+    "common.RandomStateMixin",
     "common.ServerLevelMixin",
     "common.accessor.BlockLootAccessor",
     "common.accessor.BushBlockAccessor",


### PR DESCRIPTION
exactly what it says
uses a `DensityFunction$Visitor` to give them all working, seed-based noises

---

I agree to the Contributor License Agreement (CLA).