### PR TITLE
Fix: allow candles and campfires to trigger gas

### DIFF
--- a/src/generated/resources/data/aether_ii/loot_table/entities/swet.json
+++ b/src/generated/resources/data/aether_ii/loot_table/entities/swet.json
@@ -46,78 +46,6 @@
                   "predicate": {
                     "type_specific": {
                       "type": "aether_ii:swet",
-                      "variant": "aether_ii:golden"
-                    }
-                  }
-                }
-              ],
-              "functions": [
-                {
-                  "add": false,
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "max": 3.0,
-                    "min": 1.0
-                  },
-                  "function": "minecraft:set_count"
-                },
-                {
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "max": 1.0,
-                    "min": 0.0
-                  },
-                  "enchantment": "minecraft:looting",
-                  "function": "minecraft:enchanted_count_increase"
-                }
-              ],
-              "name": "aether_ii:golden_swet_gel"
-            },
-            {
-              "type": "minecraft:item",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "aether_ii:swet",
-                      "variant": "aether_ii:purple"
-                    }
-                  }
-                }
-              ],
-              "functions": [
-                {
-                  "add": false,
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "max": 3.0,
-                    "min": 1.0
-                  },
-                  "function": "minecraft:set_count"
-                },
-                {
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "max": 1.0,
-                    "min": 0.0
-                  },
-                  "enchantment": "minecraft:looting",
-                  "function": "minecraft:enchanted_count_increase"
-                }
-              ],
-              "name": "aether_ii:purple_swet_gel"
-            },
-            {
-              "type": "minecraft:item",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "aether_ii:swet",
                       "variant": "aether_ii:blue"
                     }
                   }
@@ -154,6 +82,42 @@
                   "predicate": {
                     "type_specific": {
                       "type": "aether_ii:swet",
+                      "variant": "aether_ii:golden"
+                    }
+                  }
+                }
+              ],
+              "functions": [
+                {
+                  "add": false,
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "max": 3.0,
+                    "min": 1.0
+                  },
+                  "function": "minecraft:set_count"
+                },
+                {
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "max": 1.0,
+                    "min": 0.0
+                  },
+                  "enchantment": "minecraft:looting",
+                  "function": "minecraft:enchanted_count_increase"
+                }
+              ],
+              "name": "aether_ii:golden_swet_gel"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:entity_properties",
+                  "entity": "this",
+                  "predicate": {
+                    "type_specific": {
+                      "type": "aether_ii:swet",
                       "variant": "aether_ii:green"
                     }
                   }
@@ -180,6 +144,42 @@
                 }
               ],
               "name": "aether_ii:green_swet_gel"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:entity_properties",
+                  "entity": "this",
+                  "predicate": {
+                    "type_specific": {
+                      "type": "aether_ii:swet",
+                      "variant": "aether_ii:purple"
+                    }
+                  }
+                }
+              ],
+              "functions": [
+                {
+                  "add": false,
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "max": 3.0,
+                    "min": 1.0
+                  },
+                  "function": "minecraft:set_count"
+                },
+                {
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "max": 1.0,
+                    "min": 0.0
+                  },
+                  "enchantment": "minecraft:looting",
+                  "function": "minecraft:enchanted_count_increase"
+                }
+              ],
+              "name": "aether_ii:purple_swet_gel"
             }
           ]
         }

--- a/src/generated/resources/data/aether_ii/tags/block/hovering_block_replace_blacklist.json
+++ b/src/generated/resources/data/aether_ii/tags/block/hovering_block_replace_blacklist.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "aether_ii:aether_portal",
+    "minecraft:nether_portal",
+    "minecraft:end_portal",
+    "minecraft:end_gateway"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/triggers_gas.json
+++ b/src/generated/resources/data/aether_ii/tags/block/triggers_gas.json
@@ -1,5 +1,10 @@
 {
   "values": [
+    "#minecraft:campfires",
+    "#minecraft:fire",
+    "#minecraft:candles",
+    "minecraft:torch",
+    "minecraft:soul_torch",
     "aether_ii:ambrosium_torch",
     "aether_ii:ambrosium_wall_torch"
   ]

--- a/src/main/java/com/aetherteam/aetherii/AetherIITags.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIITags.java
@@ -84,6 +84,7 @@ public class AetherIITags {
 
         public static final TagKey<Block> HOLYSTONE_ABILITY_GUARANTEED = tag("holystone_ability_guaranteed");
         public static final TagKey<Block> GRAVITITE_ABILITY_BLACKLIST = tag("gravitite_ability_blacklist");
+        public static final TagKey<Block> HOVERING_BLOCK_REPLACE_BLACKLIST = tag("hovering_block_replace_blacklist");
 
         private static TagKey<Block> tag(String name) {
             return TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(AetherII.MODID, name));

--- a/src/main/java/com/aetherteam/aetherii/block/natural/GasBlock.java
+++ b/src/main/java/com/aetherteam/aetherii/block/natural/GasBlock.java
@@ -80,8 +80,8 @@ public class GasBlock extends Block implements CanisterPickup {
         for (Vec3i offset : INDIRECT_NEIGHBOR_OFFSETS) {
             mutablePos.setWithOffset(pos, offset);
             if (level.getBlockState(mutablePos).is(this)) {
-				if (shouldExplode(level.getBlockState(mutablePos)) || shouldExplode(state))
-					this.explode(level, pos, true);
+                if (this.shouldExplode(level.getBlockState(mutablePos)) || this.shouldExplode(state))
+                    this.explode(level, pos, true);
             }
         }
     }
@@ -103,8 +103,8 @@ public class GasBlock extends Block implements CanisterPickup {
         for (Direction direction : Direction.values()) {
             BlockPos offsetPos = pos.offset(direction.getUnitVec3i());
 
-			if (shouldExplode(level.getBlockState(offsetPos)))
-				explode(level, pos, true);
+            if (this.shouldExplode(level.getBlockState(offsetPos)))
+                this.explode(level, pos, true);
         }
         super.onPlace(state, level, pos, oldState, movedByPiston);
     }
@@ -119,20 +119,20 @@ public class GasBlock extends Block implements CanisterPickup {
         this.explode(level, pos, true);
     }
 
-	public boolean shouldExplode(BlockState state) {
-		if (!state.is(AetherIITags.Blocks.TRIGGERS_GAS))
-			return false;
+    public boolean shouldExplode(BlockState state) {
+        if (!state.is(AetherIITags.Blocks.TRIGGERS_GAS))
+            return false;
 
-		if (state.hasProperty(BlockStateProperties.LIT)) {
-			if (state.getValue(BlockStateProperties.LIT) == true) {
-				return true;
-			}
-		} else {
-			return true;
-		}
+        if (state.hasProperty(BlockStateProperties.LIT)) {
+            if (state.getValue(BlockStateProperties.LIT) == true) {
+                return true;
+            }
+        } else {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
     public void explode(LevelAccessor level, BlockPos pos, boolean playSound) {
         if (level.removeBlock(pos, false)) {
@@ -148,7 +148,7 @@ public class GasBlock extends Block implements CanisterPickup {
                 BlockPos offsetPos = pos.relative(direction);
                 if (level.getBlockState(offsetPos).getBlock() instanceof GasBlock gasBlock) {
                     gasBlock.explode(level, offsetPos, level.getRandom().nextInt(20) == 0);
-                } else if (shouldExplode(level.getBlockState(offsetPos))) {
+                } else if (this.shouldExplode(level.getBlockState(offsetPos))) {
                     level.destroyBlock(offsetPos, true);
                 }
             }
@@ -158,7 +158,7 @@ public class GasBlock extends Block implements CanisterPickup {
     @Override
     protected BlockState updateShape(BlockState state, LevelReader levelReader, ScheduledTickAccess scheduledTickAccess, BlockPos currentPos, Direction facing, BlockPos facingPos, BlockState facingState, RandomSource randomSource) {
         if (levelReader instanceof Level level) {
-            if (shouldExplode(level.getBlockState(facingPos)) || shouldExplode(state)) {
+            if (this.shouldExplode(level.getBlockState(facingPos)) || this.shouldExplode(state)) {
                 this.explode(level, currentPos, true);
                 return state;
             }

--- a/src/main/java/com/aetherteam/aetherii/block/natural/GasBlock.java
+++ b/src/main/java/com/aetherteam/aetherii/block/natural/GasBlock.java
@@ -1,5 +1,13 @@
 package com.aetherteam.aetherii.block.natural;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.BiConsumer;
+
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3i;
+
 import com.aetherteam.aetherii.AetherIITags;
 import com.aetherteam.aetherii.attachment.AetherIIDataAttachments;
 import com.aetherteam.aetherii.block.AetherIIBlocks;
@@ -7,6 +15,7 @@ import com.aetherteam.aetherii.client.particle.AetherIIParticleTypes;
 import com.aetherteam.aetherii.effect.buildup.EffectBuildupPresets;
 import com.aetherteam.aetherii.item.AetherIIItems;
 import com.aetherteam.aetherii.network.packet.clientbound.GasExplosionEffectsPacket;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
@@ -23,19 +32,13 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.Nullable;
-import org.joml.Vector3i;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.function.BiConsumer;
 
 public class GasBlock extends Block implements CanisterPickup {
     public static final int MAX_HORIZONTAL_DISTANCE = 2;
@@ -77,9 +80,8 @@ public class GasBlock extends Block implements CanisterPickup {
         for (Vec3i offset : INDIRECT_NEIGHBOR_OFFSETS) {
             mutablePos.setWithOffset(pos, offset);
             if (level.getBlockState(mutablePos).is(this)) {
-                if (level.getBlockState(mutablePos).is(AetherIITags.Blocks.TRIGGERS_GAS) || state.is(AetherIITags.Blocks.TRIGGERS_GAS)) {
-                    this.explode(level, pos, true);
-                }
+				if (shouldExplode(level.getBlockState(mutablePos)) || shouldExplode(state))
+					this.explode(level, pos, true);
             }
         }
     }
@@ -100,9 +102,9 @@ public class GasBlock extends Block implements CanisterPickup {
         level.scheduleTick(pos, this, 10);
         for (Direction direction : Direction.values()) {
             BlockPos offsetPos = pos.offset(direction.getUnitVec3i());
-            if (level.getBlockState(offsetPos).is(AetherIITags.Blocks.TRIGGERS_GAS)) {
-                this.explode(level, pos, true);
-            }
+
+			if (shouldExplode(level.getBlockState(offsetPos)))
+				explode(level, pos, true);
         }
         super.onPlace(state, level, pos, oldState, movedByPiston);
     }
@@ -116,6 +118,21 @@ public class GasBlock extends Block implements CanisterPickup {
     public void wasExploded(ServerLevel level, BlockPos pos, Explosion explosion) {
         this.explode(level, pos, true);
     }
+
+	public boolean shouldExplode(BlockState state) {
+		if (!state.is(AetherIITags.Blocks.TRIGGERS_GAS))
+			return false;
+
+		if (state.hasProperty(BlockStateProperties.LIT)) {
+			if (state.getValue(BlockStateProperties.LIT) == true) {
+				return true;
+			}
+		} else {
+			return true;
+		}
+
+		return false;
+	}
 
     public void explode(LevelAccessor level, BlockPos pos, boolean playSound) {
         if (level.removeBlock(pos, false)) {
@@ -131,7 +148,7 @@ public class GasBlock extends Block implements CanisterPickup {
                 BlockPos offsetPos = pos.relative(direction);
                 if (level.getBlockState(offsetPos).getBlock() instanceof GasBlock gasBlock) {
                     gasBlock.explode(level, offsetPos, level.getRandom().nextInt(20) == 0);
-                } else if (level.getBlockState(offsetPos).is(AetherIITags.Blocks.TRIGGERS_GAS)) {
+                } else if (shouldExplode(level.getBlockState(offsetPos))) {
                     level.destroyBlock(offsetPos, true);
                 }
             }
@@ -141,7 +158,7 @@ public class GasBlock extends Block implements CanisterPickup {
     @Override
     protected BlockState updateShape(BlockState state, LevelReader levelReader, ScheduledTickAccess scheduledTickAccess, BlockPos currentPos, Direction facing, BlockPos facingPos, BlockState facingState, RandomSource randomSource) {
         if (levelReader instanceof Level level) {
-            if (level.getBlockState(facingPos).is(AetherIITags.Blocks.TRIGGERS_GAS) || state.is(AetherIITags.Blocks.TRIGGERS_GAS)) {
+            if (shouldExplode(level.getBlockState(facingPos)) || shouldExplode(state)) {
                 this.explode(level, currentPos, true);
                 return state;
             }

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -1,16 +1,17 @@
 package com.aetherteam.aetherii.data.generators.tags;
 
+import java.util.concurrent.CompletableFuture;
+
 import com.aetherteam.aetherii.AetherII;
 import com.aetherteam.aetherii.AetherIITags;
 import com.aetherteam.aetherii.block.AetherIIBlocks;
+
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.BlockTagsProvider;
-
-import java.util.concurrent.CompletableFuture;
 
 public class AetherIIBlockTagData extends BlockTagsProvider {
     public AetherIIBlockTagData(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
@@ -264,8 +265,14 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.ARKENIUM_TRAPDOOR.get()).addTags(AetherIITags.Blocks.ICHORITE_DECORATIVE_BLOCKS, AetherIITags.Blocks.MARBLED_ICHORITE_DECORATIVE_BLOCKS);
         this.tag(AetherIITags.Blocks.ACID_INSTANTLY_DESTROYS).addTags(BlockTags.LEAVES, AetherIITags.Blocks.AERCLOUDS);
         this.tag(AetherIITags.Blocks.ACID_QUICKLY_DESTROYS).addTags(BlockTags.DIRT, BlockTags.LOGS, BlockTags.PLANKS);
-        this.tag(AetherIITags.Blocks.ACID_SLOWLY_DESTROYS).addTags(AetherIITags.Blocks.HOLYSTONE, Tags.Blocks.STONES);
+        this.tag(AetherIITags.Blocks.ACID_SLOWLY_DESTROYS).addTags(AetherIITags.Blocks.HOLYSTONE, Tags.Blocks.STONES);	
+		this.tag(AetherIITags.Blocks.TRIGGERS_GAS).addTags(
+				BlockTags.CAMPFIRES,
+				BlockTags.FIRE,
+				BlockTags.CANDLES);
         this.tag(AetherIITags.Blocks.TRIGGERS_GAS).add(
+				Blocks.TORCH,
+				Blocks.SOUL_TORCH,
                 AetherIIBlocks.AMBROSIUM_TORCH.get(),
                 AetherIIBlocks.AMBROSIUM_WALL_TORCH.get());
         this.tag(AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON).add(

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -266,13 +266,13 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
         this.tag(AetherIITags.Blocks.ACID_INSTANTLY_DESTROYS).addTags(BlockTags.LEAVES, AetherIITags.Blocks.AERCLOUDS);
         this.tag(AetherIITags.Blocks.ACID_QUICKLY_DESTROYS).addTags(BlockTags.DIRT, BlockTags.LOGS, BlockTags.PLANKS);
         this.tag(AetherIITags.Blocks.ACID_SLOWLY_DESTROYS).addTags(AetherIITags.Blocks.HOLYSTONE, Tags.Blocks.STONES);	
-		this.tag(AetherIITags.Blocks.TRIGGERS_GAS).addTags(
-				BlockTags.CAMPFIRES,
-				BlockTags.FIRE,
-				BlockTags.CANDLES);
+        this.tag(AetherIITags.Blocks.TRIGGERS_GAS).addTags(
+                BlockTags.CAMPFIRES,
+                BlockTags.FIRE,
+                BlockTags.CANDLES);
         this.tag(AetherIITags.Blocks.TRIGGERS_GAS).add(
-				Blocks.TORCH,
-				Blocks.SOUL_TORCH,
+                Blocks.TORCH,
+                Blocks.SOUL_TORCH,
                 AetherIIBlocks.AMBROSIUM_TORCH.get(),
                 AetherIIBlocks.AMBROSIUM_WALL_TORCH.get());
         this.tag(AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON).add(

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -360,6 +360,12 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 BlockTags.TRAPDOORS,
                 BlockTags.FENCE_GATES
         );
+        this.tag(AetherIITags.Blocks.HOVERING_BLOCK_REPLACE_BLACKLIST).add(
+				AetherIIBlocks.AETHER_PORTAL.get(),
+				Blocks.NETHER_PORTAL,
+                Blocks.END_PORTAL,
+				Blocks.END_GATEWAY
+        );
 
         // Vanilla
         this.tag(BlockTags.WOOL).add(

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -361,10 +361,10 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 BlockTags.FENCE_GATES
         );
         this.tag(AetherIITags.Blocks.HOVERING_BLOCK_REPLACE_BLACKLIST).add(
-				AetherIIBlocks.AETHER_PORTAL.get(),
-				Blocks.NETHER_PORTAL,
+                AetherIIBlocks.AETHER_PORTAL.get(),
+                Blocks.NETHER_PORTAL,
                 Blocks.END_PORTAL,
-				Blocks.END_GATEWAY
+                Blocks.END_GATEWAY
         );
 
         // Vanilla

--- a/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
+++ b/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
@@ -145,14 +145,14 @@ public class HoveringBlockEntity extends Entity {
     }
 
     private void markShouldSettle() {
-		Predicate<BlockPos> findPos = (pos) -> {
-			var state = level().getBlockState(pos);
+        Predicate<BlockPos> findPos = (pos) -> {
+            var state = level().getBlockState(pos);
 
-			if (state.is(AetherIITags.Blocks.HOVERING_BLOCK_REPLACE_BLACKLIST))
-				return false;
+            if (state.is(AetherIITags.Blocks.HOVERING_BLOCK_REPLACE_BLACKLIST))
+                return false;
 
-			return state.getCollisionShape(level(), pos).isEmpty();
-		};
+            return state.getCollisionShape(level(), pos).isEmpty();
+        };
 
         if (this.targetSettlePosition == null) {
             Optional<BlockPos> newPos = BlockPos.findClosestMatch(this.blockPosition(), 1, 1, findPos);

--- a/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
+++ b/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aetherii.entity.block;
 
 import com.aetherteam.aetherii.AetherII;
+import com.aetherteam.aetherii.AetherIITags;
 import com.aetherteam.aetherii.attachment.AetherIIDataAttachments;
 import com.aetherteam.aetherii.attachment.player.AetherIIPlayerAttachment;
 import com.aetherteam.aetherii.entity.AetherIIEntityTypes;
@@ -34,6 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public class HoveringBlockEntity extends Entity {
     private static final EntityDataAccessor<Integer> DATA_OWNER_ID = SynchedEntityData.defineId(HoveringBlockEntity.class, EntityDataSerializers.INT);
@@ -143,8 +145,17 @@ public class HoveringBlockEntity extends Entity {
     }
 
     private void markShouldSettle() {
+		Predicate<BlockPos> findPos = (pos) -> {
+			var state = level().getBlockState(pos);
+
+			if (state.is(AetherIITags.Blocks.HOVERING_BLOCK_REPLACE_BLACKLIST))
+				return false;
+
+			return state.getCollisionShape(level(), pos).isEmpty();
+		};
+
         if (this.targetSettlePosition == null) {
-            Optional<BlockPos> newPos = BlockPos.findClosestMatch(this.blockPosition(), 1, 1, (pos) -> this.level().getBlockState(pos).getCollisionShape(this.level(), pos).isEmpty());
+            Optional<BlockPos> newPos = BlockPos.findClosestMatch(this.blockPosition(), 1, 1, findPos);
             Vec3 targetPos = this.blockPosition().getCenter().subtract(0, 0.5, 0);
             if (newPos.isPresent()) {
                 targetPos = newPos.get().getCenter().subtract(0, 0.5, 0);


### PR DESCRIPTION
Allows lit candles and campfires to trigger gas. Unlit ones will not trigger it. This should be relatively simple to expand to include stuff like furnaces as well. 

Fixes #471 

I agree to the Contributor License Agreement (CLA).
