### PR TITLE
fix: Arrow Crash cause getWeaponItem and cow head rotate fix

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/attachment/living/DamageSystemAttachment.java
+++ b/src/main/java/com/aetherteam/aetherii/attachment/living/DamageSystemAttachment.java
@@ -22,7 +22,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.AbstractArrow;
-import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.neoforged.neoforge.common.Tags;
@@ -106,7 +105,7 @@ public class DamageSystemAttachment implements INBTSynchable {
                     slashDamage.set(livingEntity.getAttributes().hasAttribute(AetherIIAttributes.SLASH_DAMAGE) ? livingEntity.getAttributeValue(AetherIIAttributes.SLASH_DAMAGE) : 0.0);
                     impactDamage.set(livingEntity.getAttributes().hasAttribute(AetherIIAttributes.IMPACT_DAMAGE) ? livingEntity.getAttributeValue(AetherIIAttributes.IMPACT_DAMAGE) : 0.0);
                     pierceDamage.set(livingEntity.getAttributes().hasAttribute(AetherIIAttributes.PIERCE_DAMAGE) ? livingEntity.getAttributeValue(AetherIIAttributes.PIERCE_DAMAGE) : 0.0);
-                } else if (source.getDirectEntity() instanceof AbstractArrow abstractArrow && source.getEntity() instanceof LivingEntity && !abstractArrow.getWeaponItem().isEmpty()) {
+                } else if (source.getDirectEntity() instanceof AbstractArrow abstractArrow && source.getEntity() instanceof LivingEntity && abstractArrow.getWeaponItem() != null && !abstractArrow.getWeaponItem().isEmpty()) {
                     ItemStack weapon = abstractArrow.getWeaponItem();
                     ItemAttributeModifiers modifiers = weapon.getAttributeModifiers();
                     baseDamage = abstractArrow.getBaseDamage();

--- a/src/main/java/com/aetherteam/aetherii/client/renderer/entity/model/FlyingCowModel.java
+++ b/src/main/java/com/aetherteam/aetherii/client/renderer/entity/model/FlyingCowModel.java
@@ -100,8 +100,8 @@ public class FlyingCowModel<T extends WingEntityRenderState> extends EntityModel
     @Override
     public void setupAnim(T entity) {
         super.setupAnim(entity);
-        this.head.xRot = entity.yRot * Mth.DEG_TO_RAD;
-        this.head.yRot = entity.xRot * Mth.DEG_TO_RAD;
+        this.head.xRot = entity.xRot * Mth.DEG_TO_RAD;
+        this.head.yRot = entity.yRot * Mth.DEG_TO_RAD;
         this.leg_back_right.xRot = Mth.cos(entity.walkAnimationPos * 0.6662F) * 1.4F * entity.walkAnimationSpeed;
         this.leg_back_left.xRot = Mth.cos(entity.walkAnimationPos * 0.6662F + (float) Math.PI) * 1.4F * entity.walkAnimationSpeed;
         this.leg_front_right.xRot = Mth.cos(entity.walkAnimationPos * 0.6662F + (float) Math.PI) * 1.4F * entity.walkAnimationSpeed;


### PR DESCRIPTION
- Flying Cow Head Rotation Fixed
- Arrow Crash when getDamageTypeModifiedValue's getWeaponItem called(Now has null checl)