### PR TITLE
improv: various rebalances to aerclouds

### DIFF
--- a/src/generated/resources/data/aether_ii/tags/item/can_use_on_aercloud.json
+++ b/src/generated/resources/data/aether_ii/tags/item/can_use_on_aercloud.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#aether_ii:aerclouds",
+    "aether_ii:cloud_skiff"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/block/needs_iron_tool.json
+++ b/src/generated/resources/data/minecraft/tags/block/needs_iron_tool.json
@@ -1,5 +1,7 @@
 {
   "values": [
+    "aether_ii:golden_aercloud",
+    "aether_ii:storm_aercloud",
     "aether_ii:glint_ore",
     "aether_ii:arkenium_ore",
     "aether_ii:gravitite_ore",

--- a/src/generated/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/src/generated/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -1,5 +1,8 @@
 {
   "values": [
+    "aether_ii:blue_aercloud",
+    "aether_ii:green_aercloud",
+    "aether_ii:purple_aercloud",
     "aether_ii:undershale",
     "aether_ii:undershale_stairs",
     "aether_ii:undershale_slab",

--- a/src/main/java/com/aetherteam/aetherii/AetherIIEventListeners.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIIEventListeners.java
@@ -184,7 +184,7 @@ public class AetherIIEventListeners {
         boolean cancelled = false;
 
         cancelled = PlayerHooks.playerActivatePortal(player, level, pos, face, itemStack, hand, cancelled);
-        cancelled = PlayerHooks.cancelPlacementOnAercloud(level, pos, itemStack, cancelled);
+        cancelled = PlayerHooks.cancelPlacementOnAercloud(player, level, pos, itemStack, cancelled);
         cancelled = PlayerHooks.snowlogBlock(player, level, pos, itemStack, hand, cancelled);
         cancelled = PlayerHooks.ferrositeMudBottleConversion(player, level, pos, itemStack, hand, face, cancelled);
         cancelled = PlayerHooks.interactWithMimicContainer(level, pos, cancelled);

--- a/src/main/java/com/aetherteam/aetherii/AetherIIEventListeners.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIIEventListeners.java
@@ -184,6 +184,7 @@ public class AetherIIEventListeners {
         boolean cancelled = false;
 
         cancelled = PlayerHooks.playerActivatePortal(player, level, pos, face, itemStack, hand, cancelled);
+        cancelled = PlayerHooks.cancelPlacementOnAercloud(level, pos, itemStack, cancelled);
         cancelled = PlayerHooks.snowlogBlock(player, level, pos, itemStack, hand, cancelled);
         cancelled = PlayerHooks.ferrositeMudBottleConversion(player, level, pos, itemStack, hand, face, cancelled);
         cancelled = PlayerHooks.interactWithMimicContainer(level, pos, cancelled);

--- a/src/main/java/com/aetherteam/aetherii/AetherIITags.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIITags.java
@@ -215,6 +215,7 @@ public class AetherIITags {
         public static final TagKey<Item> MOA_FOOD = tag("moa_food");
 
         public static final TagKey<Item> AETHER_PORTAL_ACTIVATION_ITEMS = tag("aether_portal_activation_items");
+        public static final TagKey<Item> CAN_USE_ON_AERCLOUD = tag("can_use_on_aercloud");
         public static final TagKey<Item> GOLDEN_AMBER_HARVESTERS = tag("golden_amber_harvesters");
         public static final TagKey<Item> DOUBLE_DROPS = tag("double_drops");
         public static final TagKey<Item> IRRADIATED_ITEM = tag("irradiated_item");

--- a/src/main/java/com/aetherteam/aetherii/block/AetherIIBlockBuilders.java
+++ b/src/main/java/com/aetherteam/aetherii/block/AetherIIBlockBuilders.java
@@ -16,7 +16,7 @@ import net.minecraft.world.level.material.PushReaction;
 import java.util.function.Supplier;
 
 public class AetherIIBlockBuilders {
-    public static Supplier<Block.Properties> aercloudProperties(MapColor mapColor) {
+    public static Supplier<Block.Properties> coldAercloudProperties(MapColor mapColor) {
         return () -> Block.Properties.of()
                 .mapColor(mapColor)
                 .instrument(NoteBlockInstrument.FLUTE)
@@ -29,6 +29,22 @@ public class AetherIIBlockBuilders {
                 .isRedstoneConductor(AetherIIBlockBuilders::never)
                 .isSuffocating(AetherIIBlockBuilders::never)
                 .isViewBlocking(AetherIIBlockBuilders::never);
+    }
+
+    public static Supplier<Block.Properties> specialAercloudProperties(MapColor mapColor) {
+        return () -> Block.Properties.of()
+                .mapColor(mapColor)
+                .instrument(NoteBlockInstrument.FLUTE)
+                .strength(0.9F)
+                .sound(SoundType.WOOL)
+                .noOcclusion()
+                .dynamicShape()
+                .forceSolidOn()
+                .isValidSpawn((state, level, pos, entityType) -> entityType.is(AetherIITags.Entities.SPAWNING_AERCLOUDS))
+                .isRedstoneConductor(AetherIIBlockBuilders::never)
+                .isSuffocating(AetherIIBlockBuilders::never)
+                .isViewBlocking(AetherIIBlockBuilders::never)
+                .requiresCorrectToolForDrops();
     }
 
     public static Supplier<Block.Properties> logProperties(MapColor topMapColor, MapColor sideMapColor) {

--- a/src/main/java/com/aetherteam/aetherii/block/AetherIIBlocks.java
+++ b/src/main/java/com/aetherteam/aetherii/block/AetherIIBlocks.java
@@ -149,12 +149,12 @@ public class AetherIIBlocks extends AetherIIBlockBuilders {
     public static final DeferredBlock<Block> CORROBONITE_CLUSTER = register("corrobonite_cluster", CorroboniteClusterBlock::new, () -> Block.Properties.of().mapColor(MapColor.WOOL).strength(3.0F, 3.0F).replaceable().noOcclusion().noCollission().instabreak());
 
     // Aerclouds
-    public static final DeferredBlock<Block> COLD_AERCLOUD = register("cold_aercloud", AercloudBlock::new, aercloudProperties(MapColor.SNOW));
-    public static final DeferredBlock<Block> GOLDEN_AERCLOUD = register("golden_aercloud", AercloudBlock::new, aercloudProperties(MapColor.COLOR_YELLOW));
-    public static final DeferredBlock<Block> BLUE_AERCLOUD = register("blue_aercloud", BlueAercloudBlock::new, aercloudProperties(MapColor.COLOR_LIGHT_BLUE));
-    public static final DeferredBlock<Block> GREEN_AERCLOUD = register("green_aercloud", GreenAercloudBlock::new, aercloudProperties(MapColor.COLOR_LIGHT_GREEN));
-    public static final DeferredBlock<Block> PURPLE_AERCLOUD = register("purple_aercloud", PurpleAercloudBlock::new, aercloudProperties(MapColor.COLOR_MAGENTA));
-    public static final DeferredBlock<Block> STORM_AERCLOUD = register("storm_aercloud", AercloudBlock::new, aercloudProperties(MapColor.DEEPSLATE));
+    public static final DeferredBlock<Block> COLD_AERCLOUD = register("cold_aercloud", AercloudBlock::new, coldAercloudProperties(MapColor.SNOW));
+    public static final DeferredBlock<Block> GOLDEN_AERCLOUD = register("golden_aercloud", AercloudBlock::new, specialAercloudProperties(MapColor.COLOR_YELLOW));
+    public static final DeferredBlock<Block> BLUE_AERCLOUD = register("blue_aercloud", BlueAercloudBlock::new, specialAercloudProperties(MapColor.COLOR_LIGHT_BLUE));
+    public static final DeferredBlock<Block> GREEN_AERCLOUD = register("green_aercloud", GreenAercloudBlock::new, specialAercloudProperties(MapColor.COLOR_LIGHT_GREEN));
+    public static final DeferredBlock<Block> PURPLE_AERCLOUD = register("purple_aercloud", PurpleAercloudBlock::new, specialAercloudProperties(MapColor.COLOR_MAGENTA));
+    public static final DeferredBlock<Block> STORM_AERCLOUD = register("storm_aercloud", AercloudBlock::new, specialAercloudProperties(MapColor.DEEPSLATE));
 
     // Moa Nest
     public static final DeferredBlock<Block> WOVEN_SKYROOT_STICKS = register("woven_skyroot_sticks", WovenSticksBlock::new, () -> Block.Properties.of().mapColor(MapColor.COLOR_BROWN).strength(0.75F).sound(SoundType.GRASS));

--- a/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
+++ b/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
@@ -1,13 +1,12 @@
 package com.aetherteam.aetherii.block.natural;
 
 import com.aetherteam.aetherii.AetherIITags;
-import com.aetherteam.aetherii.block.AetherIIBlocks;
 import com.aetherteam.aetherii.entity.vehicle.CloudSkiff;
-import com.aetherteam.aetherii.item.AetherIIItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.InsideBlockEffectApplier;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.BlockItem;
@@ -30,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockContainer {
     protected static final VoxelShape COLLISION_SHAPE = Block.box(0.0, 0.0, 0.0, 16.0, 0.01, 16.0);
     protected static final VoxelShape FALLING_COLLISION_SHAPE = Shapes.box(0.0, 0.0, 0.0, 1.0, 0.9, 1.0);
+    protected static final VoxelShape ITEM_COLLISION_SHAPE = Shapes.box(0.0, 0.0, 0.0, 1.0, 0.65, 1.0);
 
     public AercloudBlock(Properties properties) {
         super(properties);
@@ -47,10 +47,14 @@ public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockCo
     @Override
     public void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, InsideBlockEffectApplier effectApplier) {
         entity.resetFallDistance();
-        if (entity.getDeltaMovement().y < -0.0784000015258789 && !(entity instanceof Projectile) && !(entity instanceof CloudSkiff)) {
-            entity.setDeltaMovement(entity.getDeltaMovement().multiply(1.0, 0.25, 1.0));
+        if (!(entity instanceof ItemEntity itemEntity)) {
+            if (entity.getDeltaMovement().y < -0.0784000015258789 && !(entity instanceof Projectile) && !(entity instanceof CloudSkiff)) {
+                entity.setDeltaMovement(entity.getDeltaMovement().multiply(1.0, 0.25, 1.0));
+            } else {
+                entity.setOnGround(entity instanceof LivingEntity livingEntity && (!(livingEntity instanceof Player player) || !player.getAbilities().flying));
+            }
         } else {
-            entity.setOnGround(entity instanceof LivingEntity livingEntity && (!(livingEntity instanceof Player player) || !player.getAbilities().flying));
+            itemEntity.setDeltaMovement(entity.getDeltaMovement().scale(0.99F));
         }
     }
 
@@ -112,6 +116,8 @@ public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockCo
                     } else {
                         return Shapes.empty();
                     }
+                } else if (entity instanceof ItemEntity) {
+                    return ITEM_COLLISION_SHAPE;
                 } else if (entity.fallDistance > 2.5F && (!(entity instanceof LivingEntity livingEntity) || !livingEntity.isFallFlying())) {
                     return FALLING_COLLISION_SHAPE; // Alternate shape when falling fast enough.
                 }
@@ -122,7 +128,11 @@ public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockCo
 
     @Override
     public float getFriction(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
-        return entity instanceof CloudSkiff ? 0.92F : super.getFriction(state, level, pos, entity);
+        if (!(entity instanceof ItemEntity)) {
+            return entity instanceof CloudSkiff ? 0.92F : super.getFriction(state, level, pos, entity);
+        } else {
+            return 0.85F;
+        }
     }
 
     protected VoxelShape getDefaultCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {

--- a/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
+++ b/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
@@ -1,6 +1,5 @@
 package com.aetherteam.aetherii.block.natural;
 
-import com.aetherteam.aetherii.AetherIITags;
 import com.aetherteam.aetherii.entity.vehicle.CloudSkiff;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
@@ -9,7 +8,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
@@ -147,14 +145,6 @@ public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockCo
     @Override
     public VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return Shapes.empty();
-    }
-
-    @Override
-    protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        if (context instanceof EntityCollisionContext entityCollisionContext && entityCollisionContext.getEntity() instanceof Player player) {
-            return player.isHolding((stack) -> stack.getItem() instanceof BlockItem) && !player.isHolding((stack) -> stack.is(AetherIITags.Items.CAN_USE_ON_AERCLOUD)) ? Shapes.empty() : Shapes.block();
-        }
-        return Shapes.block();
     }
 
     @Override

--- a/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
+++ b/src/main/java/com/aetherteam/aetherii/block/natural/AercloudBlock.java
@@ -1,12 +1,16 @@
 package com.aetherteam.aetherii.block.natural;
 
+import com.aetherteam.aetherii.AetherIITags;
+import com.aetherteam.aetherii.block.AetherIIBlocks;
 import com.aetherteam.aetherii.entity.vehicle.CloudSkiff;
+import com.aetherteam.aetherii.item.AetherIIItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.InsideBlockEffectApplier;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
@@ -133,6 +137,14 @@ public class AercloudBlock extends HalfTransparentBlock implements LiquidBlockCo
     @Override
     public VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return Shapes.empty();
+    }
+
+    @Override
+    protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        if (context instanceof EntityCollisionContext entityCollisionContext && entityCollisionContext.getEntity() instanceof Player player) {
+            return player.isHolding((stack) -> stack.getItem() instanceof BlockItem) && !player.isHolding((stack) -> stack.is(AetherIITags.Items.CAN_USE_ON_AERCLOUD)) ? Shapes.empty() : Shapes.block();
+        }
+        return Shapes.block();
     }
 
     @Override

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -1150,6 +1150,9 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.AMBRELINN_MOSS_CARPET.get()
         );
         this.tag(BlockTags.NEEDS_STONE_TOOL).add(
+                AetherIIBlocks.BLUE_AERCLOUD.get(),
+                AetherIIBlocks.GREEN_AERCLOUD.get(),
+                AetherIIBlocks.PURPLE_AERCLOUD.get(),
                 AetherIIBlocks.UNDERSHALE.get(),
                 AetherIIBlocks.UNDERSHALE_STAIRS.get(),
                 AetherIIBlocks.UNDERSHALE_SLAB.get(),
@@ -1198,6 +1201,8 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.ZANITE_BLOCK.get()
         );
         this.tag(BlockTags.NEEDS_IRON_TOOL).add(
+                AetherIIBlocks.GOLDEN_AERCLOUD.get(),
+                AetherIIBlocks.STORM_AERCLOUD.get(),
                 AetherIIBlocks.GLINT_ORE.get(),
                 AetherIIBlocks.ARKENIUM_ORE.get(),
                 AetherIIBlocks.GRAVITITE_ORE.get(),

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIItemTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIItemTagData.java
@@ -329,9 +329,7 @@ public class AetherIIItemTagData extends ItemTagsProvider {
         this.tag(AetherIITags.Items.SENTRY_BOOTS_REPAIRING);
         this.tag(AetherIITags.Items.NEPTUNE_REPAIRING);
         this.tag(AetherIITags.Items.AETHER_PORTAL_ACTIVATION_ITEMS);
-        this.tag(AetherIITags.Items.CAN_USE_ON_AERCLOUD).addTag(AetherIITags.Items.AERCLOUDS).add(
-                AetherIIItems.CLOUD_SKIFF.get()
-        );
+        this.tag(AetherIITags.Items.CAN_USE_ON_AERCLOUD).addTag(AetherIITags.Items.AERCLOUDS);
         this.tag(AetherIITags.Items.GOLDEN_AMBER_HARVESTERS).add(
                 AetherIIItems.HOLYSTONE_AXE.get(),
                 AetherIIItems.ZANITE_AXE.get(),

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIItemTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIItemTagData.java
@@ -329,6 +329,9 @@ public class AetherIIItemTagData extends ItemTagsProvider {
         this.tag(AetherIITags.Items.SENTRY_BOOTS_REPAIRING);
         this.tag(AetherIITags.Items.NEPTUNE_REPAIRING);
         this.tag(AetherIITags.Items.AETHER_PORTAL_ACTIVATION_ITEMS);
+        this.tag(AetherIITags.Items.CAN_USE_ON_AERCLOUD).addTag(AetherIITags.Items.AERCLOUDS).add(
+                AetherIIItems.CLOUD_SKIFF.get()
+        );
         this.tag(AetherIITags.Items.GOLDEN_AMBER_HARVESTERS).add(
                 AetherIIItems.HOLYSTONE_AXE.get(),
                 AetherIIItems.ZANITE_AXE.get(),

--- a/src/main/java/com/aetherteam/aetherii/event/hooks/PlayerHooks.java
+++ b/src/main/java/com/aetherteam/aetherii/event/hooks/PlayerHooks.java
@@ -29,6 +29,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
+import net.minecraft.util.ParticleUtils;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -52,6 +53,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -90,6 +92,22 @@ public class PlayerHooks {
                         return true;
                     }
                 }
+            }
+        }
+        return cancellationStatus;
+    }
+
+    public static boolean cancelPlacementOnAercloud(LevelAccessor levelAccessor, BlockPos pos, ItemStack itemStack, boolean cancellationStatus) {
+        BlockState state = levelAccessor.getBlockState(pos);
+
+        if (state.is(AetherIITags.Blocks.AERCLOUDS)) {
+            if (itemStack.getItem() instanceof BlockItem && !itemStack.is(AetherIITags.Items.CAN_USE_ON_AERCLOUD)) {
+                if (levelAccessor.isClientSide() && levelAccessor instanceof Level level) {
+                    for (int i = 0; i < 10; i++) {
+                        ParticleUtils.spawnParticleOnFace(level, pos, Direction.UP, ParticleTypes.POOF, Vec3.ZERO, 0.5F);
+                    }
+                }
+                return true;
             }
         }
         return cancellationStatus;

--- a/src/main/java/com/aetherteam/aetherii/event/hooks/PlayerHooks.java
+++ b/src/main/java/com/aetherteam/aetherii/event/hooks/PlayerHooks.java
@@ -97,16 +97,17 @@ public class PlayerHooks {
         return cancellationStatus;
     }
 
-    public static boolean cancelPlacementOnAercloud(LevelAccessor levelAccessor, BlockPos pos, ItemStack itemStack, boolean cancellationStatus) {
-        BlockState state = levelAccessor.getBlockState(pos);
+    public static boolean cancelPlacementOnAercloud(Player player, Level level, BlockPos pos, ItemStack itemStack, boolean cancellationStatus) {
+        BlockState state = level.getBlockState(pos);
 
         if (state.is(AetherIITags.Blocks.AERCLOUDS)) {
             if (itemStack.getItem() instanceof BlockItem && !itemStack.is(AetherIITags.Items.CAN_USE_ON_AERCLOUD)) {
-                if (levelAccessor.isClientSide() && levelAccessor instanceof Level level) {
+                if (level.isClientSide()) {
                     for (int i = 0; i < 10; i++) {
                         ParticleUtils.spawnParticleOnFace(level, pos, Direction.UP, ParticleTypes.POOF, Vec3.ZERO, 0.5F);
                     }
                 }
+                level.playSound(null, pos, state.getSoundType(level, pos, player).getPlaceSound(), SoundSource.BLOCKS, 1.0F, 1.0F);
                 return true;
             }
         }

--- a/src/main/java/com/aetherteam/aetherii/item/AetherIICreativeTabs.java
+++ b/src/main/java/com/aetherteam/aetherii/item/AetherIICreativeTabs.java
@@ -433,10 +433,10 @@ public class AetherIICreativeTabs {
                 output.accept(AetherIIBlocks.INERT_ARKENIUM_BLOCK.get());
                 output.accept(AetherIIBlocks.INERT_GRAVITITE_BLOCK.get());
                 output.accept(AetherIIBlocks.COLD_AERCLOUD.get());
-                output.accept(AetherIIBlocks.GOLDEN_AERCLOUD.get());
                 output.accept(AetherIIBlocks.BLUE_AERCLOUD.get());
                 output.accept(AetherIIBlocks.GREEN_AERCLOUD.get());
                 output.accept(AetherIIBlocks.PURPLE_AERCLOUD.get());
+                output.accept(AetherIIBlocks.GOLDEN_AERCLOUD.get());
                 output.accept(AetherIIBlocks.STORM_AERCLOUD.get());
                 output.accept(AetherIIBlocks.WOVEN_SKYROOT_STICKS.get());
                 output.accept(AetherIIBlocks.TANGLED_BRANCHES.get());


### PR DESCRIPTION
- Blocks can no longer be placed on Aerclouds, with the exception of other Aerclouds.
- Blue, Green, and Purple Aerclouds now require a Holystone-tier Trowel to harvest.
- Gold and Storm Aerclouds now require a Zanite-tier Trowel to harvest.
- Items no longer slide away so far when dropped in Aerclouds.