### PR TITLE
feat: more bugfixes and improvements before alpha

### DIFF
--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/crude_scatterglass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/crude_scatterglass_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:crude_scatterglass_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:crude_scatterglass_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:crude_scatterglass_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/crude_scatterglass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/crude_scatterglass_pane_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:crude_scatterglass_pane_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:crude_scatterglass_pane_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:crude_scatterglass_pane_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/quicksoil_glass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/quicksoil_glass_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:quicksoil_glass_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:quicksoil_glass_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:quicksoil_glass_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/quicksoil_glass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/quicksoil_glass_pane_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:quicksoil_glass_pane_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:quicksoil_glass_pane_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:quicksoil_glass_pane_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/scatterglass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/scatterglass_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:scatterglass_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:scatterglass_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:scatterglass_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/scatterglass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/advancement/recipes/building_blocks/scatterglass_pane_from_artisanry.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_artisanry_blocks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#aether_ii:scatterglass_pane_decorative_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "aether_ii:scatterglass_pane_from_artisanry"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_artisanry_blocks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "aether_ii:scatterglass_pane_from_artisanry"
+    ]
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/crude_scatterglass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/crude_scatterglass_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_from_artisanry",
+  "ingredients": [
+    "#aether_ii:crude_scatterglass_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:crude_scatterglass"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/crude_scatterglass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/crude_scatterglass_pane_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_pane_from_artisanry",
+  "ingredients": [
+    "#aether_ii:crude_scatterglass_pane_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:crude_scatterglass_pane"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/faded_holystone_bricks_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/faded_holystone_bricks_from_artisanry.json
@@ -3,7 +3,7 @@
   "category": "building",
   "group": "bricks_from_artisanry",
   "ingredients": [
-    "#aether_ii:holystone_decorative_blocks"
+    "#aether_ii:faded_holystone_decorative_blocks"
   ],
   "result": {
     "count": 1,

--- a/src/generated/resources/data/aether_ii/recipe/quicksoil_glass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/quicksoil_glass_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_from_artisanry",
+  "ingredients": [
+    "#aether_ii:quicksoil_glass_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:quicksoil_glass"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/quicksoil_glass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/quicksoil_glass_pane_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_pane_from_artisanry",
+  "ingredients": [
+    "#aether_ii:quicksoil_glass_pane_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:quicksoil_glass_pane"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/scatterglass_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/scatterglass_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_from_artisanry",
+  "ingredients": [
+    "#aether_ii:scatterglass_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:scatterglass"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/scatterglass_pane_from_artisanry.json
+++ b/src/generated/resources/data/aether_ii/recipe/scatterglass_pane_from_artisanry.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "glass_pane_from_artisanry",
+  "ingredients": [
+    "#aether_ii:scatterglass_pane_decorative_blocks"
+  ],
+  "result": {
+    "count": 1,
+    "id": "aether_ii:scatterglass_pane"
+  }
+}

--- a/src/generated/resources/data/aether_ii/recipe/swet_jelly.json
+++ b/src/generated/resources/data/aether_ii/recipe/swet_jelly.json
@@ -6,7 +6,7 @@
     "aether_ii:swet_sugar"
   ],
   "result": {
-    "count": 2,
+    "count": 1,
     "id": "aether_ii:swet_jelly"
   }
 }

--- a/src/generated/resources/data/aether_ii/tags/block/crude_scatterglass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/crude_scatterglass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_crude_scatterglass",
+    "aether_ii:arkenium_framed_crude_scatterglass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/crude_scatterglass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/crude_scatterglass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_crude_scatterglass_pane",
+    "aether_ii:arkenium_framed_crude_scatterglass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/quicksoil_glass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/quicksoil_glass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:tiled_quicksoil_glass",
+    "aether_ii:gridded_quicksoil_glass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/quicksoil_glass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/quicksoil_glass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:tiled_quicksoil_glass_pane",
+    "aether_ii:gridded_quicksoil_glass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/scatterglass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/scatterglass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_scatterglass",
+    "aether_ii:arkenium_framed_scatterglass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/block/scatterglass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/block/scatterglass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_scatterglass_pane",
+    "aether_ii:arkenium_framed_scatterglass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/crude_scatterglass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/crude_scatterglass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_crude_scatterglass",
+    "aether_ii:arkenium_framed_crude_scatterglass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/crude_scatterglass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/crude_scatterglass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_crude_scatterglass_pane",
+    "aether_ii:arkenium_framed_crude_scatterglass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/quicksoil_glass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/quicksoil_glass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:tiled_quicksoil_glass",
+    "aether_ii:gridded_quicksoil_glass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/quicksoil_glass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/quicksoil_glass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:tiled_quicksoil_glass_pane",
+    "aether_ii:gridded_quicksoil_glass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/scatterglass_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/scatterglass_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_scatterglass",
+    "aether_ii:arkenium_framed_scatterglass"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/tags/item/scatterglass_pane_decorative_blocks.json
+++ b/src/generated/resources/data/aether_ii/tags/item/scatterglass_pane_decorative_blocks.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "aether_ii:skyroot_framed_scatterglass_pane",
+    "aether_ii:arkenium_framed_scatterglass_pane"
+  ]
+}

--- a/src/generated/resources/data/aether_ii/worldgen/biome/battleground_wastes.json
+++ b/src/generated/resources/data/aether_ii/worldgen/biome/battleground_wastes.json
@@ -73,6 +73,7 @@
       "aether_ii:enchanted_grass_and_dirt_floor",
       "aether_ii:coarse_aether_dirt_floor",
       "aether_ii:blueberry_bush_patch_irradiated",
+      "aether_ii:brettl_patch_irradiated",
       "aether_ii:battleground_wastes_trees"
     ],
     [

--- a/src/generated/resources/data/aether_ii/worldgen/biome/battleground_wastes.json
+++ b/src/generated/resources/data/aether_ii/worldgen/biome/battleground_wastes.json
@@ -72,6 +72,7 @@
       "aether_ii:irradiated_grass_patch",
       "aether_ii:enchanted_grass_and_dirt_floor",
       "aether_ii:coarse_aether_dirt_floor",
+      "aether_ii:blueberry_bush_patch_irradiated",
       "aether_ii:battleground_wastes_trees"
     ],
     [

--- a/src/generated/resources/data/aether_ii/worldgen/biome/contaminated_jungle.json
+++ b/src/generated/resources/data/aether_ii/worldgen/biome/contaminated_jungle.json
@@ -64,6 +64,7 @@
       "aether_ii:water_spring"
     ],
     [
+      "aether_ii:orange_tree_patch_irradiated",
       "aether_ii:grass_field",
       "aether_ii:small_grass_patch",
       "aether_ii:medium_grass_patch",
@@ -71,6 +72,7 @@
       "aether_ii:irradiated_grass_patch",
       "aether_ii:enchanted_grass_and_dirt_floor",
       "aether_ii:coarse_aether_dirt_floor",
+      "aether_ii:blueberry_bush_patch_irradiated",
       "aether_ii:contaminated_jungle_trees"
     ],
     [

--- a/src/generated/resources/data/aether_ii/worldgen/biome/contaminated_jungle.json
+++ b/src/generated/resources/data/aether_ii/worldgen/biome/contaminated_jungle.json
@@ -73,6 +73,7 @@
       "aether_ii:enchanted_grass_and_dirt_floor",
       "aether_ii:coarse_aether_dirt_floor",
       "aether_ii:blueberry_bush_patch_irradiated",
+      "aether_ii:brettl_patch_irradiated",
       "aether_ii:contaminated_jungle_trees"
     ],
     [

--- a/src/generated/resources/data/aether_ii/worldgen/biome/enduring_woodland.json
+++ b/src/generated/resources/data/aether_ii/worldgen/biome/enduring_woodland.json
@@ -63,6 +63,7 @@
       "aether_ii:small_grass_patch",
       "aether_ii:medium_grass_patch",
       "aether_ii:large_grass_patch",
+      "aether_ii:blueberry_bush_patch_rare",
       "aether_ii:orange_tree_patch_rare",
       "aether_ii:grass_and_dirt_floor",
       "aether_ii:coarse_aether_dirt_floor",

--- a/src/generated/resources/data/aether_ii/worldgen/configured_feature/blueberry_bush_rare.json
+++ b/src/generated/resources/data/aether_ii/worldgen/configured_feature/blueberry_bush_rare.json
@@ -1,0 +1,63 @@
+{
+  "type": "minecraft:random_patch",
+  "config": {
+    "feature": {
+      "feature": {
+        "type": "minecraft:simple_block",
+        "config": {
+          "to_place": {
+            "type": "minecraft:simple_state_provider",
+            "state": {
+              "Name": "aether_ii:blueberry_bush",
+              "Properties": {
+                "waterlogged": "false"
+              }
+            }
+          }
+        }
+      },
+      "placement": [
+        {
+          "type": "minecraft:block_predicate_filter",
+          "predicate": {
+            "type": "minecraft:all_of",
+            "predicates": [
+              {
+                "type": "minecraft:any_of",
+                "predicates": [
+                  {
+                    "type": "minecraft:matching_block_tag",
+                    "offset": [
+                      0,
+                      -1,
+                      0
+                    ],
+                    "tag": "aether_ii:aether_plant_survives_on"
+                  },
+                  {
+                    "type": "aether_ii:mossy",
+                    "offset": [
+                      0,
+                      -1,
+                      0
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "minecraft:replaceable"
+              },
+              {
+                "type": "minecraft:matching_fluids",
+                "fluids": "minecraft:empty"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "tries": 32,
+    "xz_spread": 2,
+    "y_spread": 3
+  }
+}

--- a/src/generated/resources/data/aether_ii/worldgen/placed_feature/blueberry_bush_patch_irradiated.json
+++ b/src/generated/resources/data/aether_ii/worldgen/placed_feature/blueberry_bush_patch_irradiated.json
@@ -1,0 +1,56 @@
+{
+  "feature": "aether_ii:blueberry_bush_rare",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 24
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "aether_ii:aether_plant_survives_on"
+              },
+              {
+                "type": "aether_ii:mossy",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              }
+            ]
+          },
+          {
+            "type": "minecraft:replaceable"
+          },
+          {
+            "type": "minecraft:matching_fluids",
+            "fluids": "minecraft:empty"
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/generated/resources/data/aether_ii/worldgen/placed_feature/blueberry_bush_patch_rare.json
+++ b/src/generated/resources/data/aether_ii/worldgen/placed_feature/blueberry_bush_patch_rare.json
@@ -1,0 +1,56 @@
+{
+  "feature": "aether_ii:blueberry_bush_rare",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 20
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "aether_ii:aether_plant_survives_on"
+              },
+              {
+                "type": "aether_ii:mossy",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              }
+            ]
+          },
+          {
+            "type": "minecraft:replaceable"
+          },
+          {
+            "type": "minecraft:matching_fluids",
+            "fluids": "minecraft:empty"
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/generated/resources/data/aether_ii/worldgen/placed_feature/brettl_patch_irradiated.json
+++ b/src/generated/resources/data/aether_ii/worldgen/placed_feature/brettl_patch_irradiated.json
@@ -1,0 +1,56 @@
+{
+  "feature": "aether_ii:brettl_plant",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 2
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "aether_ii:brettl_plant_survives_on"
+              },
+              {
+                "type": "aether_ii:mossy",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              }
+            ]
+          },
+          {
+            "type": "minecraft:replaceable"
+          },
+          {
+            "type": "minecraft:matching_fluids",
+            "fluids": "minecraft:empty"
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/generated/resources/data/aether_ii/worldgen/placed_feature/orange_tree_patch_irradiated.json
+++ b/src/generated/resources/data/aether_ii/worldgen/placed_feature/orange_tree_patch_irradiated.json
@@ -1,0 +1,56 @@
+{
+  "feature": "aether_ii:orange_tree_patch",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 24
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "aether_ii:aether_plant_survives_on"
+              },
+              {
+                "type": "aether_ii:mossy",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              }
+            ]
+          },
+          {
+            "type": "minecraft:replaceable"
+          },
+          {
+            "type": "minecraft:matching_fluids",
+            "fluids": "minecraft:empty"
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/java/com/aetherteam/aetherii/AetherIITags.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIITags.java
@@ -46,6 +46,12 @@ public class AetherIITags {
         public static final TagKey<Block> MARBLED_ICHORITE_DECORATIVE_BLOCKS = tag("marbled_ichorite_decorative_blocks");
         public static final TagKey<Block> AGIOSITE_DECORATIVE_BLOCKS = tag("agiosite_decorative_blocks");
         public static final TagKey<Block> ICESTONE_DECORATIVE_BLOCKS = tag("icestone_decorative_blocks");
+        public static final TagKey<Block> QUICKSOIL_GLASS_DECORATIVE_BLOCKS = tag("quicksoil_glass_decorative_blocks");
+        public static final TagKey<Block> QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS = tag("quicksoil_glass_pane_decorative_blocks");
+        public static final TagKey<Block> CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS = tag("crude_scatterglass_decorative_blocks");
+        public static final TagKey<Block> CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS = tag("crude_scatterglass_pane_decorative_blocks");
+        public static final TagKey<Block> SCATTERGLASS_DECORATIVE_BLOCKS = tag("scatterglass_decorative_blocks");
+        public static final TagKey<Block> SCATTERGLASS_PANE_DECORATIVE_BLOCKS = tag("scatterglass_pane_decorative_blocks");
         public static final TagKey<Block> SENTRY_BLOCKS = tag("sentry_blocks");
         public static final TagKey<Block> QUICKSOIL_GLASS = tag("quicksoil_glass");
         public static final TagKey<Block> CRUDE_SCATTERGLASS = tag("crude_scatterglass");
@@ -138,6 +144,12 @@ public class AetherIITags {
         public static final TagKey<Item> MARBLED_ICHORITE_DECORATIVE_BLOCKS = tag("marbled_ichorite_decorative_blocks");
         public static final TagKey<Item> AGIOSITE_DECORATIVE_BLOCKS = tag("agiosite_decorative_blocks");
         public static final TagKey<Item> ICESTONE_DECORATIVE_BLOCKS = tag("icestone_decorative_blocks");
+        public static final TagKey<Item> QUICKSOIL_GLASS_DECORATIVE_BLOCKS = tag("quicksoil_glass_decorative_blocks");
+        public static final TagKey<Item> QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS = tag("quicksoil_glass_pane_decorative_blocks");
+        public static final TagKey<Item> CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS = tag("crude_scatterglass_decorative_blocks");
+        public static final TagKey<Item> CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS = tag("crude_scatterglass_pane_decorative_blocks");
+        public static final TagKey<Item> SCATTERGLASS_DECORATIVE_BLOCKS = tag("scatterglass_decorative_blocks");
+        public static final TagKey<Item> SCATTERGLASS_PANE_DECORATIVE_BLOCKS = tag("scatterglass_pane_decorative_blocks");
         public static final TagKey<Item> ARILUM_LANTERN = tag("arilum_lantern");
 
         public static final TagKey<Item> GUARDIAN_LOGS = tag("guardian_logs");

--- a/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIRecipeData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIRecipeData.java
@@ -552,7 +552,7 @@ public class AetherIIRecipeData extends AetherIIRecipeProvider {
         SimpleCookingRecipeBuilder.smelting(Ingredient.of(AetherIIBlocks.HOLYSTONE_BRICKS.get()), RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.FADED_HOLYSTONE_BRICKS.get(), 0.1F, 200).unlockedBy(getHasName(AetherIIBlocks.HOLYSTONE_BRICKS.get()), has(AetherIIBlocks.HOLYSTONE_BRICKS.get())).save(this.output);
         ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.FADED_HOLYSTONE_BRICKS.get())
                 .group("bricks_from_artisanry")
-                .requires(AetherIITags.Items.HOLYSTONE_DECORATIVE_BLOCKS)
+                .requires(AetherIITags.Items.FADED_HOLYSTONE_DECORATIVE_BLOCKS)
                 .unlockedBy("has_faded_holystone_blocks", has(AetherIITags.Items.FADED_HOLYSTONE_DECORATIVE_BLOCKS))
                 .save(this.output, name("faded_holystone_bricks_from_artisanry"));
         this.stairs(AetherIIBlocks.FADED_HOLYSTONE_BRICK_STAIRS, AetherIIBlocks.FADED_HOLYSTONE_BRICKS).save(this.output);
@@ -935,6 +935,21 @@ public class AetherIIRecipeData extends AetherIIRecipeProvider {
         // Glass
         this.altarEnchanting(RecipeCategory.MISC, AetherIIBlocks.QUICKSOIL_GLASS, AetherIIBlocks.QUICKSOIL, 1, 0.0F).save(this.output);
         SimpleCookingRecipeBuilder.smelting(Ingredient.of(AetherIIBlocks.CRUDE_SCATTERGLASS.get()), RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.SCATTERGLASS.get(), 0.1F, 200).unlockedBy("has_crude_scatterglass", has(AetherIIBlocks.CRUDE_SCATTERGLASS.get())).save(this.output);
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.QUICKSOIL_GLASS.get())
+                .group("glass_from_artisanry")
+                .requires(AetherIITags.Items.QUICKSOIL_GLASS_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.QUICKSOIL_GLASS_DECORATIVE_BLOCKS))
+                .save(this.output, name("quicksoil_glass_from_artisanry"));
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.CRUDE_SCATTERGLASS.get())
+                .group("glass_from_artisanry")
+                .requires(AetherIITags.Items.CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS))
+                .save(this.output, name("crude_scatterglass_from_artisanry"));
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.SCATTERGLASS.get())
+                .group("glass_from_artisanry")
+                .requires(AetherIITags.Items.SCATTERGLASS_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.SCATTERGLASS_DECORATIVE_BLOCKS))
+                .save(this.output, name("scatterglass_from_artisanry"));
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.TILED_QUICKSOIL_GLASS.get(), AetherIIBlocks.QUICKSOIL_GLASS.get());
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.GRIDDED_QUICKSOIL_GLASS.get(), AetherIIBlocks.QUICKSOIL_GLASS.get());
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.SKYROOT_FRAMED_CRUDE_SCATTERGLASS.get(), AetherIIBlocks.CRUDE_SCATTERGLASS.get());
@@ -953,6 +968,21 @@ public class AetherIIRecipeData extends AetherIIRecipeProvider {
         ShapedRecipeBuilder.shaped(getter, RecipeCategory.DECORATIONS, AetherIIBlocks.CRUDE_SCATTERGLASS_PANE.get(), 16).define('#', AetherIIBlocks.CRUDE_SCATTERGLASS.get()).pattern("###").pattern("###").unlockedBy("has_crude_scatterglass", has(AetherIIBlocks.CRUDE_SCATTERGLASS.get())).save(this.output);
         ShapedRecipeBuilder.shaped(getter, RecipeCategory.DECORATIONS, AetherIIBlocks.SCATTERGLASS_PANE.get(), 16).define('#', AetherIIBlocks.SCATTERGLASS.get()).pattern("###").pattern("###").unlockedBy("has_scatterglass", has(AetherIIBlocks.SCATTERGLASS.get())).save(this.output);
         SimpleCookingRecipeBuilder.smelting(Ingredient.of(AetherIIBlocks.CRUDE_SCATTERGLASS_PANE.get()), RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.SCATTERGLASS_PANE.get(), 0.1F, 200).unlockedBy("has_crude_scatterglass_pane", has(AetherIIBlocks.CRUDE_SCATTERGLASS_PANE.get())).save(this.output, name("scatterglass_pane_from_smelting"));
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.QUICKSOIL_GLASS_PANE.get())
+                .group("glass_pane_from_artisanry")
+                .requires(AetherIITags.Items.QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS))
+                .save(this.output, name("quicksoil_glass_pane_from_artisanry"));
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.CRUDE_SCATTERGLASS_PANE.get())
+                .group("glass_pane_from_artisanry")
+                .requires(AetherIITags.Items.CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS))
+                .save(this.output, name("crude_scatterglass_pane_from_artisanry"));
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.BUILDING_BLOCKS, AetherIIBlocks.SCATTERGLASS_PANE.get())
+                .group("glass_pane_from_artisanry")
+                .requires(AetherIITags.Items.SCATTERGLASS_PANE_DECORATIVE_BLOCKS)
+                .unlockedBy("has_artisanry_blocks", has(AetherIITags.Items.SCATTERGLASS_PANE_DECORATIVE_BLOCKS))
+                .save(this.output, name("scatterglass_pane_from_artisanry"));
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.TILED_QUICKSOIL_GLASS_PANE.get(), AetherIIBlocks.QUICKSOIL_GLASS_PANE.get());
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.GRIDDED_QUICKSOIL_GLASS_PANE.get(), AetherIIBlocks.QUICKSOIL_GLASS_PANE.get());
         this.stonecuttingRecipe(this.output, RecipeCategory.DECORATIONS, AetherIIBlocks.SKYROOT_FRAMED_CRUDE_SCATTERGLASS_PANE.get(), AetherIIBlocks.CRUDE_SCATTERGLASS_PANE.get());

--- a/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIRecipeData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIRecipeData.java
@@ -2193,7 +2193,7 @@ public class AetherIIRecipeData extends AetherIIRecipeProvider {
         this.oneToOneConversionRecipe(Items.PURPLE_DYE, AetherIIBlocks.AECHOR_CUTTING, "purple_dye");
         this.oneToOneConversionRecipe(Items.LIGHT_BLUE_DYE, AetherIIBlocks.CARRION_CUTTING, "light_blue_dye");
 
-        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.MISC, AetherIIItems.SWET_JELLY.get(), 2)
+        ShapelessRecipeBuilder.shapeless(getter, RecipeCategory.MISC, AetherIIItems.SWET_JELLY.get(), 1)
                 .requires(AetherIIItems.SWET_GEL)
                 .requires(AetherIIItems.SWET_SUGAR)
                 .unlockedBy("has_gel", has(AetherIIItems.SWET_GEL))

--- a/src/main/java/com/aetherteam/aetherii/data/providers/AetherIIBlockItemTagProvider.java
+++ b/src/main/java/com/aetherteam/aetherii/data/providers/AetherIIBlockItemTagProvider.java
@@ -230,6 +230,30 @@ public abstract class AetherIIBlockItemTagProvider {
                 AetherIIBlocks.ICESTONE_CAPSTONE_PILLAR.get(),
                 AetherIIBlocks.ICESTONE_PILLAR.get()
         );
+        this.tag(AetherIITags.Blocks.QUICKSOIL_GLASS_DECORATIVE_BLOCKS, AetherIITags.Items.QUICKSOIL_GLASS_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.TILED_QUICKSOIL_GLASS.get(),
+                AetherIIBlocks.GRIDDED_QUICKSOIL_GLASS.get()
+        );
+        this.tag(AetherIITags.Blocks.QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS, AetherIITags.Items.QUICKSOIL_GLASS_PANE_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.TILED_QUICKSOIL_GLASS_PANE.get(),
+                AetherIIBlocks.GRIDDED_QUICKSOIL_GLASS_PANE.get()
+        );
+        this.tag(AetherIITags.Blocks.CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS, AetherIITags.Items.CRUDE_SCATTERGLASS_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.SKYROOT_FRAMED_CRUDE_SCATTERGLASS.get(),
+                AetherIIBlocks.ARKENIUM_FRAMED_CRUDE_SCATTERGLASS.get()
+        );
+        this.tag(AetherIITags.Blocks.CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS, AetherIITags.Items.CRUDE_SCATTERGLASS_PANE_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.SKYROOT_FRAMED_CRUDE_SCATTERGLASS_PANE.get(),
+                AetherIIBlocks.ARKENIUM_FRAMED_CRUDE_SCATTERGLASS_PANE.get()
+        );
+        this.tag(AetherIITags.Blocks.SCATTERGLASS_DECORATIVE_BLOCKS, AetherIITags.Items.SCATTERGLASS_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.SKYROOT_FRAMED_SCATTERGLASS.get(),
+                AetherIIBlocks.ARKENIUM_FRAMED_SCATTERGLASS.get()
+        );
+        this.tag(AetherIITags.Blocks.SCATTERGLASS_PANE_DECORATIVE_BLOCKS, AetherIITags.Items.SCATTERGLASS_PANE_DECORATIVE_BLOCKS).add(
+                AetherIIBlocks.SKYROOT_FRAMED_SCATTERGLASS_PANE.get(),
+                AetherIIBlocks.ARKENIUM_FRAMED_SCATTERGLASS_PANE.get()
+        );
         this.tag(AetherIITags.Blocks.ARILUM_LANTERN, AetherIITags.Items.ARILUM_LANTERN).add(
                 AetherIIBlocks.WHITE_ARILUM_LANTERN.get(),
                 AetherIIBlocks.ORANGE_ARILUM_LANTERN.get(),

--- a/src/main/java/com/aetherteam/aetherii/data/resources/builders/worldgen/holyisles/HolyIslesBiomeBuilders.java
+++ b/src/main/java/com/aetherteam/aetherii/data/resources/builders/worldgen/holyisles/HolyIslesBiomeBuilders.java
@@ -608,6 +608,7 @@ public class HolyIslesBiomeBuilders {
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ENCHANTED_GRASS_AND_DIRT_FLOOR)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.COARSE_AETHER_DIRT_FLOOR)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.BLUEBERRY_BUSH_PATCH_IRRADIATED)
+                .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.BRETTL_PATCH_IRRADIATED)
                 .addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, HolyIslesPlacedFeatures.POINTED_HOLYSTONE)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_STORM_AERCLOUD)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_GREEN_AERCLOUD)

--- a/src/main/java/com/aetherteam/aetherii/data/resources/builders/worldgen/holyisles/HolyIslesBiomeBuilders.java
+++ b/src/main/java/com/aetherteam/aetherii/data/resources/builders/worldgen/holyisles/HolyIslesBiomeBuilders.java
@@ -436,6 +436,7 @@ public class HolyIslesBiomeBuilders {
                         .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.SMALL_GRASS_PATCH)
                         .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.MEDIUM_GRASS_PATCH)
                         .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.LARGE_GRASS_PATCH)
+                        .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.BLUEBERRY_BUSH_PATCH_RARE)
                         .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ORANGE_TREE_PATCH_RARE)
                         .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.FREEZE_TOP_LAYER_ARCTIC),
                 new MobSpawnSettings.Builder().creatureGenerationProbability(0.18F)
@@ -490,8 +491,7 @@ public class HolyIslesBiomeBuilders {
     }
 
     public static Biome makeArcticBiome(Optional<ResourceKey<PlacedFeature>> tree, BiomeGenerationSettings.Builder builder, MobSpawnSettings.Builder spawnSettingsBuilder,  float temperature, float downfall, boolean precipitation) {
-        builder = builder
-                .addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.COAST_ARCTIC_PACKED_ICE)
+        builder = builder.addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.COAST_ARCTIC_PACKED_ICE)
                 .addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.NOISE_LAKE_ARCTIC)
                 .addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.CLOUDBED)
                 .addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.COASTAL_ARCTIC_ICE_SPIKE)
@@ -513,13 +513,13 @@ public class HolyIslesBiomeBuilders {
                 .addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, HolyIslesPlacedFeatures.ORE_HESTVEIL_BURIED)
                 .addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, HolyIslesPlacedFeatures.UNSTABLE_HOLYSTONE)
                 .addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, HolyIslesPlacedFeatures.UNSTABLE_UNDERSHALE)
+                .addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, HolyIslesPlacedFeatures.POINTED_HOLYSTONE)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.GRASS_AND_DIRT_FLOOR)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.COARSE_AETHER_DIRT_FLOOR)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.COARSE_AETHER_DIRT_FROSTED_CEILING)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ICE_OVERHANG)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.HOLY_ISLES_FLOWER_PATCH)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ARCTIC_FLOWER_PATCH)
-                .addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, HolyIslesPlacedFeatures.POINTED_HOLYSTONE)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_STORM_AERCLOUD)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_GREEN_AERCLOUD)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_PURPLE_AERCLOUD)
@@ -566,7 +566,9 @@ public class HolyIslesBiomeBuilders {
     }
 
     public static Biome contaminatedJungleBiome(HolderGetter<PlacedFeature> placedFeatures, HolderGetter<ConfiguredWorldCarver<?>> worldCarvers, float temperature, float downfall) {
-        return makeIrradiatedBiome(Optional.of(HolyIslesPlacedFeatures.CONTAMINATED_JUNGLE_TREES), new BiomeGenerationSettings.Builder(placedFeatures, worldCarvers), temperature, downfall);
+        return makeIrradiatedBiome(Optional.of(HolyIslesPlacedFeatures.CONTAMINATED_JUNGLE_TREES), new BiomeGenerationSettings.Builder(placedFeatures, worldCarvers)
+                       .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ORANGE_TREE_PATCH_IRRADIATED),
+                temperature, downfall);
     }
 
     public static Biome battlegroundWastesBiome(HolderGetter<PlacedFeature> placedFeatures, HolderGetter<ConfiguredWorldCarver<?>> worldCarvers, float temperature, float downfall) {
@@ -577,8 +579,7 @@ public class HolyIslesBiomeBuilders {
 
     public static Biome makeIrradiatedBiome(Optional<ResourceKey<PlacedFeature>> tree, BiomeGenerationSettings.Builder builder, float temperature, float downfall) {
         MobSpawnSettings.Builder spawnSettingsBuilder = new MobSpawnSettings.Builder();
-        builder = builder.addCarver(AetherIICarvers.HOLY_ISLES_CAVE)
-                .addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.CLOUDBED)
+        builder = builder.addCarver(AetherIICarvers.HOLY_ISLES_CAVE).addFeature(GenerationStep.Decoration.RAW_GENERATION, HolyIslesPlacedFeatures.CLOUDBED)
                 .addFeature(GenerationStep.Decoration.LAKES, HolyIslesPlacedFeatures.WATER_POND)
                 .addFeature(GenerationStep.Decoration.LAKES, HolyIslesPlacedFeatures.WATER_POND_UNDERGROUND)
                 .addFeature(GenerationStep.Decoration.LAKES, HolyIslesPlacedFeatures.ALKAHEST_POOL_RARE)
@@ -606,6 +607,7 @@ public class HolyIslesBiomeBuilders {
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.IRRADIATED_GRASS_PATCH)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.ENCHANTED_GRASS_AND_DIRT_FLOOR)
                 .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.COARSE_AETHER_DIRT_FLOOR)
+                .addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, HolyIslesPlacedFeatures.BLUEBERRY_BUSH_PATCH_IRRADIATED)
                 .addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, HolyIslesPlacedFeatures.POINTED_HOLYSTONE)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_STORM_AERCLOUD)
                 .addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, HolyIslesPlacedFeatures.HIGH_GREEN_AERCLOUD)

--- a/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesConfiguredFeatures.java
+++ b/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesConfiguredFeatures.java
@@ -87,6 +87,7 @@ public class HolyIslesConfiguredFeatures {
     public static final ResourceKey<ConfiguredFeature<?, ?>> VALKYRIE_SPROUT_PATCH = createKey("valkyrie_sprout_patch");
     public static final ResourceKey<ConfiguredFeature<?, ?>> AETHER_BUSH = createKey("aether_bush");
     public static final ResourceKey<ConfiguredFeature<?, ?>> BLUEBERRY_BUSH = createKey("blueberry_bush");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> BLUEBERRY_BUSH_RARE = createKey("blueberry_bush_rare");
     public static final ResourceKey<ConfiguredFeature<?, ?>> ORANGE_TREE = createKey("orange_tree_patch");
     public static final ResourceKey<ConfiguredFeature<?, ?>> BRETTL_PLANT = createKey("brettl_plant");
 
@@ -607,6 +608,19 @@ public class HolyIslesConfiguredFeatures {
                 Feature.RANDOM_PATCH,
                 new RandomPatchConfiguration(
                         55,
+                        2,
+                        3,
+                        PlacementUtils.filtered(Feature.SIMPLE_BLOCK, new SimpleBlockConfiguration(
+                                BlockStateProvider.simple(AetherIIBlocks.BLUEBERRY_BUSH.get().defaultBlockState())
+                        ), BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid()))
+                )
+        );
+        register(
+                context,
+                BLUEBERRY_BUSH_RARE,
+                Feature.RANDOM_PATCH,
+                new RandomPatchConfiguration(
+                        32,
                         2,
                         3,
                         PlacementUtils.filtered(Feature.SIMPLE_BLOCK, new SimpleBlockConfiguration(

--- a/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesPlacedFeatures.java
+++ b/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesPlacedFeatures.java
@@ -57,8 +57,11 @@ public class HolyIslesPlacedFeatures {
     public static final ResourceKey<PlacedFeature> AETHER_BUSH_PATCH = createKey("aether_bush_patch");
     public static final ResourceKey<PlacedFeature> AETHER_BUSH_PATCH_FIELD = createKey("aether_bush_patch_field");
     public static final ResourceKey<PlacedFeature> BLUEBERRY_BUSH_PATCH = createKey("blueberry_bush_patch");
+    public static final ResourceKey<PlacedFeature> BLUEBERRY_BUSH_PATCH_RARE = createKey("blueberry_bush_patch_rare");
+    public static final ResourceKey<PlacedFeature> BLUEBERRY_BUSH_PATCH_IRRADIATED = createKey("blueberry_bush_patch_irradiated");
     public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH = createKey("orange_tree_patch");
     public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH_RARE = createKey("orange_tree_patch_rare");
+    public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH_IRRADIATED = createKey("orange_tree_patch_irradiated");
 
     public static final ResourceKey<PlacedFeature> HOLY_ISLES_FLOWER_PATCH = createKey("holy_isles_flower_patch");
     public static final ResourceKey<PlacedFeature> HIGHFIELDS_FLOWER_PATCH = createKey("highfields_flower_patch");
@@ -398,6 +401,18 @@ public class HolyIslesPlacedFeatures {
                 InSquarePlacement.spread(),
                 PlacementUtils.HEIGHTMAP,
                 BiomeFilter.biome());
+        register(context, BLUEBERRY_BUSH_PATCH_RARE, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.BLUEBERRY_BUSH_RARE),
+                RarityFilter.onAverageOnceEvery(20),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),
+                BiomeFilter.biome());
+        register(context, BLUEBERRY_BUSH_PATCH_IRRADIATED, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.BLUEBERRY_BUSH_RARE),
+                RarityFilter.onAverageOnceEvery(24),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),
+                BiomeFilter.biome());
         register(context, ORANGE_TREE_PATCH, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.ORANGE_TREE),
                 NoiseBasedCountPlacement.of(3, 10, 0),
                 InSquarePlacement.spread(),
@@ -406,6 +421,12 @@ public class HolyIslesPlacedFeatures {
                 BiomeFilter.biome());
         register(context, ORANGE_TREE_PATCH_RARE, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.ORANGE_TREE),
                 RarityFilter.onAverageOnceEvery(20),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),
+                BiomeFilter.biome());
+        register(context, ORANGE_TREE_PATCH_IRRADIATED, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.ORANGE_TREE),
+                RarityFilter.onAverageOnceEvery(24),
                 InSquarePlacement.spread(),
                 PlacementUtils.HEIGHTMAP,
                 BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),

--- a/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesPlacedFeatures.java
+++ b/src/main/java/com/aetherteam/aetherii/data/resources/registries/holyisles/HolyIslesPlacedFeatures.java
@@ -62,6 +62,7 @@ public class HolyIslesPlacedFeatures {
     public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH = createKey("orange_tree_patch");
     public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH_RARE = createKey("orange_tree_patch_rare");
     public static final ResourceKey<PlacedFeature> ORANGE_TREE_PATCH_IRRADIATED = createKey("orange_tree_patch_irradiated");
+    public static final ResourceKey<PlacedFeature> BRETTL_PATCH_IRRADIATED = createKey("brettl_patch_irradiated");
 
     public static final ResourceKey<PlacedFeature> HOLY_ISLES_FLOWER_PATCH = createKey("holy_isles_flower_patch");
     public static final ResourceKey<PlacedFeature> HIGHFIELDS_FLOWER_PATCH = createKey("highfields_flower_patch");
@@ -430,6 +431,12 @@ public class HolyIslesPlacedFeatures {
                 InSquarePlacement.spread(),
                 PlacementUtils.HEIGHTMAP,
                 BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.AETHER_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),
+                BiomeFilter.biome());
+        register(context, BRETTL_PATCH_IRRADIATED, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.BRETTL_PLANT),
+                CountPlacement.of(2),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BlockPredicateFilter.forPredicate(BlockPredicate.allOf(BlockPredicate.anyOf(BlockPredicate.matchesTag(Vec3i.ZERO.below(), AetherIITags.Blocks.BRETTL_PLANT_SURVIVES_ON), new MossyPredicate(Vec3i.ZERO.below())), BlockPredicate.replaceable(), BlockPredicate.noFluid())),
                 BiomeFilter.biome());
 
         register(context, HOLY_ISLES_FLOWER_PATCH, configuredFeatures.getOrThrow(HolyIslesConfiguredFeatures.HOLY_ISLES_FLOWER_PATCH),

--- a/src/main/java/com/aetherteam/aetherii/item/AetherIIFoods.java
+++ b/src/main/java/com/aetherteam/aetherii/item/AetherIIFoods.java
@@ -10,7 +10,7 @@ public class AetherIIFoods {
     public static final FoodProperties WYNDBERRY = new FoodProperties.Builder().nutrition(3).saturationModifier(0.4F).build();
     public static final FoodProperties ENCHANTED_WYNDBERRY = new FoodProperties.Builder().nutrition(10).saturationModifier(0.6F).build();
     public static final FoodProperties SATIVAL_BULB = new FoodProperties.Builder().nutrition(2).saturationModifier(0.1F).build();
-    public static final FoodProperties SWET_JELLY = new FoodProperties.Builder().nutrition(5).saturationModifier(0.4F).build();
+    public static final FoodProperties SWET_JELLY = new FoodProperties.Builder().nutrition(6).saturationModifier(0.6F).build();
     public static final FoodProperties BURRUKAI_RIB_CUT = new FoodProperties.Builder().nutrition(4).saturationModifier(0.3F).build();
     public static final FoodProperties BURRUKAI_RIBS = new FoodProperties.Builder().nutrition(8).saturationModifier(0.8F).build();
     public static final FoodProperties KIRRID_LOIN = new FoodProperties.Builder().nutrition(2).saturationModifier(0.3F).build();


### PR DESCRIPTION
- added rare blueberry bushes to enduring woodlands and irradiated biomes
- added rare orange generation to contaminated jungles
- reduced swet jelly crafting recipe output back to 1
- improved swet jelly hunger values a little
- fixed faded holystone decorative blocks not being able to be crafted back into faded holystone bricks
- fixed glass decorative blocks not being able to be crafted back into their regular variants
- fixed holystone decorative blocks crafting back into faded holystone bricks instead of regular holystone bricks