### PR TITLE
improv: advancement tweaks

### DIFF
--- a/src/generated/resources/assets/aether_ii/lang/en_us.json
+++ b/src/generated/resources/assets/aether_ii/lang/en_us.json
@@ -49,7 +49,7 @@
   "advancement.aether_ii.glint": "Who wants to be a Glintillionaire?",
   "advancement.aether_ii.glint.desc": "Earn at least 1000 Glint Coins",
   "advancement.aether_ii.golden_amber": "Wisdom of the Ancients",
-  "advancement.aether_ii.golden_amber.desc": "Harvest Golden Amber from an Amberoot tree using the proper tool",
+  "advancement.aether_ii.golden_amber.desc": "Harvest Golden Amber from an Amberoot tree using at minimum a Holystone tier axe",
   "advancement.aether_ii.gravitite_armor": "Defying Gravity",
   "advancement.aether_ii.gravitite_armor.desc": "Wear 3 pieces of Gravitite Armor to activate its set ability",
   "advancement.aether_ii.gravitite_plate": "Pink is the New Blue",

--- a/src/generated/resources/assets/aether_ii/lang/en_us.json
+++ b/src/generated/resources/assets/aether_ii/lang/en_us.json
@@ -47,7 +47,7 @@
   "advancement.aether_ii.explore_aether": "The World Above",
   "advancement.aether_ii.explore_aether.desc": "Explore all Aether biomes",
   "advancement.aether_ii.glint": "Who wants to be a Glintillionaire?",
-  "advancement.aether_ii.glint.desc": "Earn at least 100 Glint Coins",
+  "advancement.aether_ii.glint.desc": "Earn at least 1000 Glint Coins",
   "advancement.aether_ii.golden_amber": "Wisdom of the Ancients",
   "advancement.aether_ii.golden_amber.desc": "Harvest Golden Amber from an Amberoot tree using the proper tool",
   "advancement.aether_ii.gravitite_armor": "Defying Gravity",

--- a/src/generated/resources/data/aether_ii/advancement/glint.json
+++ b/src/generated/resources/data/aether_ii/advancement/glint.json
@@ -3,7 +3,7 @@
   "criteria": {
     "glint": {
       "conditions": {
-        "amount": 100
+        "amount": 1000
       },
       "trigger": "aether_ii:currency"
     }

--- a/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIAdvancementData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/AetherIIAdvancementData.java
@@ -235,7 +235,7 @@ public class AetherIIAdvancementData extends AdvancementProvider {
                             Component.translatable("advancement.aether_ii.glint.desc").withStyle(ChatFormatting.AQUA),
                             null,
                             AdvancementType.GOAL, true, true, false)
-                    .addCriterion("glint", CurrencyTrigger.Instance.forValue(100))
+                    .addCriterion("glint", CurrencyTrigger.Instance.forValue(1000))
                     .save(consumer, ResourceLocation.fromNamespaceAndPath(AetherII.MODID, "glint"));
 
             AdvancementHolder bestiary = createBestiaryAdvancement(outpostCampfire, consumer);

--- a/src/main/java/com/aetherteam/aetherii/data/generators/AetherIILanguageData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/AetherIILanguageData.java
@@ -1633,13 +1633,13 @@ public class AetherIILanguageData extends AetherIILanguageProvider {
         this.addAdvancementDesc("antitoxin", "Consume an Antitoxin or Antivenom Vial to reduce the buildup of poison effects");
         this.addAdvancementDesc("engraved_discs", "Collect all Aether engraved discs");
         this.addAdvancementDesc("outpost_campfire", "Set a secondary respawn point at an Outpost Campfire");
-        this.addAdvancementDesc("glint", "Earn at least 100 Glint Coins");
+        this.addAdvancementDesc("glint", "Earn at least 1000 Glint Coins");
         this.addAdvancementDesc("bestiary", "Fill out the entire bestiary");
         this.addAdvancementDesc("trowel", "Harvest drops from a wild plant using any Trowel");
         this.addAdvancementDesc("enchanted_aether_grass", "Enchant an Aether Grass Block with an Ambrosium Shard to speed up plant growth above it");
         this.addAdvancementDesc("plant_cutting", "Harvest a cutting from an Aechor Plant or Carrion Sprout");
         this.addAdvancementDesc("ambrosium", "Obtain an Ambrosium Shard");
-        this.addAdvancementDesc("golden_amber", "Harvest Golden Amber from an Amberoot tree using the proper tool");
+        this.addAdvancementDesc("golden_amber", "Harvest Golden Amber from an Amberoot tree using at minimum a Holystone tier axe");
         this.addAdvancementDesc("amber_hourglass", "Craft an Amber Hourglass");
         this.addAdvancementDesc("zanite", "Restore Fossilized Zanite into a Zanite Gemstone using the Amber Hourglass");
         this.addAdvancementDesc("craft_altar", "Craft an Altar");


### PR DESCRIPTION
- Glint advancement now requires 1000 instead of 100 glint coins
- Golden Amber obtaining advancement now specifies requiring at least holystone tier tool