### PR TITLE
fix: hovering state handled by server

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/attachment/player/AbilityBehaviorAttachment.java
+++ b/src/main/java/com/aetherteam/aetherii/attachment/player/AbilityBehaviorAttachment.java
@@ -1,5 +1,6 @@
 package com.aetherteam.aetherii.attachment.player;
 
+import com.aetherteam.aetherii.AetherII;
 import com.aetherteam.aetherii.attachment.AetherIIDataAttachments;
 import com.aetherteam.aetherii.item.AetherIIItems;
 import com.aetherteam.aetherii.item.consumables.HealingStoneItem;
@@ -78,10 +79,10 @@ public class AbilityBehaviorAttachment {
 
     public void login(Player player) {
         this.shouldSyncAfterJoin = true;
+        player.getData(AetherIIDataAttachments.ABILITY_BEHAVIOR).gravititeHoldingFloatingBlock = false;
     }
 
     public void logout(Player player) {
-
     }
 
     public void onJoinLevel(Player player) {

--- a/src/main/java/com/aetherteam/aetherii/entity/AetherIIEntityTypes.java
+++ b/src/main/java/com/aetherteam/aetherii/entity/AetherIIEntityTypes.java
@@ -153,7 +153,7 @@ public class AetherIIEntityTypes {
 
     // Blocks
     public static final DeferredHolder<EntityType<?>, EntityType<HoveringBlockEntity>> HOVERING_BLOCK = ENTITY_TYPES.register("hovering_block",
-            () -> EntityType.Builder.<HoveringBlockEntity>of(HoveringBlockEntity::new, MobCategory.MISC).sized(0.9F, 0.9F).clientTrackingRange(10).updateInterval(20).noLootTable().build(AetherIIEntities.HOVERING_BLOCK));
+            () -> EntityType.Builder.<HoveringBlockEntity>of(HoveringBlockEntity::new, MobCategory.MISC).sized(0.9F, 0.9F).clientTrackingRange(10).updateInterval(1).noLootTable().build(AetherIIEntities.HOVERING_BLOCK));
 
     // Vehicles
     public static final DeferredHolder<EntityType<?>, EntityType<CloudSkiff>> CLOUD_SKIFF = ENTITY_TYPES.register("cloud_skiff",

--- a/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
+++ b/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
@@ -77,7 +77,13 @@ public class HoveringBlockEntity extends Entity {
 
     @Override
     public void tick() {
+        if (this.level().isClientSide) {
+            this.interpolation.interpolate();
+            return;
+        }
+
         Entity holdingPlayer = this.getHoldingPlayer();
+
         if (this.held) {
             if (holdingPlayer != null) {
                 Vec3 playerToBlock = this.position().subtract(holdingPlayer.position().add(0, 1.15, 0));
@@ -106,7 +112,6 @@ public class HoveringBlockEntity extends Entity {
             this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
 
-        this.interpolation.interpolate();
 
         this.move(MoverType.SELF, this.getDeltaMovement());
 
@@ -170,6 +175,9 @@ public class HoveringBlockEntity extends Entity {
         Vec3 currentPos = this.position();
         Vec3 motion = this.targetSettlePosition.subtract(currentPos);
         BlockPos newPos = BlockPos.containing(this.targetSettlePosition.x(), this.targetSettlePosition.y(), this.targetSettlePosition.z());
+
+        AetherII.LOGGER.info(newPos.toShortString());
+
         this.setDeltaMovement(motion);
         if (holdingPlayer != null) {
             holdingPlayer.getData(AetherIIDataAttachments.ABILITY_BEHAVIOR).setGravititeHoldingFloatingBlock(false);

--- a/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
+++ b/src/main/java/com/aetherteam/aetherii/entity/block/HoveringBlockEntity.java
@@ -175,9 +175,6 @@ public class HoveringBlockEntity extends Entity {
         Vec3 currentPos = this.position();
         Vec3 motion = this.targetSettlePosition.subtract(currentPos);
         BlockPos newPos = BlockPos.containing(this.targetSettlePosition.x(), this.targetSettlePosition.y(), this.targetSettlePosition.z());
-
-        AetherII.LOGGER.info(newPos.toShortString());
-
         this.setDeltaMovement(motion);
         if (holdingPlayer != null) {
             holdingPlayer.getData(AetherIIDataAttachments.ABILITY_BEHAVIOR).setGravititeHoldingFloatingBlock(false);


### PR DESCRIPTION
`(TITLE)`: type(scope): Brief description *[MOVE TO TITLE]*

Write up a description here

closes issue #XXXX [REMOVE IF IRRELEVANT]

---

I agree to the Contributor License Agreement (CLA).


### [Example Below; REMOVE FOR SUBMISSION]

`(TITLE)` feat(block): Implements Aether Grass Block

Implements the Aether Grass Block class, model, blockstates, language entry, and adds the block to the registry
  
closes issue #790 

---

I agree to the Contributor License Agreement (CLA).
