### PR TITLE
fix: aether grass breaking particle colors (#823)

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/client/AetherIIClientExtensions.java
+++ b/src/main/java/com/aetherteam/aetherii/client/AetherIIClientExtensions.java
@@ -110,6 +110,13 @@ public class AetherIIClientExtensions {
         }
     };
 
+    public static final IClientBlockExtensions AETHER_GRASS = new IClientBlockExtensions() {
+        @Override
+        public boolean areBreakingParticlesTinted(BlockState state, ClientLevel level, BlockPos pos) {
+            return false;
+        }
+    };
+
     public static final IClientItemExtensions GLIDER = new IClientItemExtensions() {
         @Nullable
         @Override
@@ -217,6 +224,7 @@ public class AetherIIClientExtensions {
         event.registerItem(MOA_SADDLE, AetherIIItems.MOA_SADDLE);
 
         event.registerBlock(UNSTABLE_BLOCK, AetherIIBlocks.UNSTABLE_HOLYSTONE.get(), AetherIIBlocks.UNSTABLE_UNDERSHALE.get(), AetherIIBlocks.FRAGILE_ARCTIC_ICE.get(), AetherIIBlocks.UNSTABLE_GUARDIAN_ROOTS.get());
+        event.registerBlock(AETHER_GRASS, AetherIIBlocks.AETHER_GRASS_BLOCK.get());
 
         event.registerFluidType(ALKAHEST_FLUID, AetherIIFluidTypes.ALKAHEST_TYPE.get());
 


### PR DESCRIPTION
fix(block): aether grass breaking particle colors

Updates AetherIIClientExtensions to prevent Aether Grass block breaking particles from incorrectly receiving the foliage colorizer tint.

closes issue #823 

---

I agree to the Contributor License Agreement (CLA).