### PR TITLE
fix: artisan's bench displays as a block for stonecutting recipes

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/integration/jei/AetherIIJEIPlugin.java
+++ b/src/main/java/com/aetherteam/aetherii/integration/jei/AetherIIJEIPlugin.java
@@ -60,6 +60,7 @@ public class AetherIIJEIPlugin implements IModPlugin {
         registration.addCraftingStation(RecipeTypes.CRAFTING, AetherIIBlocks.SKYROOT_CRAFTING_TABLE);
         registration.addCraftingStation(RecipeTypes.SMELTING, AetherIIBlocks.HOLYSTONE_FURNACE);
         registration.addCraftingStation(RecipeTypes.SMELTING_FUEL, AetherIIBlocks.HOLYSTONE_FURNACE);
+        registration.addCraftingStation(RecipeTypes.STONECUTTING, AetherIIBlocks.ARTISANS_BENCH);
     }
 
     @Override


### PR DESCRIPTION
closes #802 

<img width="854" height="480" alt="2026-03-05_16 09 59" src="https://github.com/user-attachments/assets/81847cfa-0620-44c7-8626-3b8bc1e74349" />
