### PR TITLE
fix(zanite-equipment): Fix zanite buff calculations

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/item/equipment/ZaniteBuff.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/ZaniteBuff.java
@@ -7,6 +7,6 @@ public interface ZaniteBuff {
     double buff = 1.0;
 
     default double calculateZaniteBuff(ItemStack stack) {
-        return buff * stack.getDamageValue() / (double) stack.getMaxDamage();
+        return 1.0e-10 + buff * stack.getDamageValue() / (double) stack.getMaxDamage();
     }
 }

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/ZaniteBuff.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/ZaniteBuff.java
@@ -3,7 +3,10 @@ package com.aetherteam.aetherii.item.equipment;
 import net.minecraft.world.item.ItemStack;
 
 public interface ZaniteBuff {
-    default double calculateZaniteBuff(ItemStack stack, double baseValue) {
-        return baseValue * (2.0 * ((double) stack.getDamageValue()) / ((double) stack.getMaxDamage()) + 0.5);
+    /// Added Multiplier buff (1 => + 100%, .5 => + 50%, etc.)
+    double buff = 1.0;
+
+    default double calculateZaniteBuff(ItemStack stack) {
+        return buff * stack.getDamageValue() / (double) stack.getMaxDamage();
     }
 }

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/accessories/ZanitePendantItem.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/accessories/ZanitePendantItem.java
@@ -31,7 +31,7 @@ public class ZanitePendantItem extends AccessoryItem {
     @Override
     public Set<ConditionalAttribute> gatherAttributes(Set<ConditionalAttribute> attributes) {
         attributes = super.gatherAttributes(attributes);
-        attributes.add(new ConditionalAttribute(Attributes.MINING_EFFICIENCY, new ConditionalModifier(MINING_EFFICIENCY, (stack) -> 0.25 + (1.75 * stack.getDamageValue() / (stack.getMaxDamage() + 0.5)), AttributeModifier.Operation.ADD_VALUE), (stack, wearer) -> true));
+        attributes.add(new ConditionalAttribute(Attributes.BLOCK_BREAK_SPEED, new ConditionalModifier(MINING_EFFICIENCY, (stack) -> 0.25 + (1.75 * stack.getDamageValue() / (stack.getMaxDamage() + 0.5)), AttributeModifier.Operation.ADD_VALUE), (stack, wearer) -> true));
         return attributes;
     }
 

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/accessories/ZanitePendantItem.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/accessories/ZanitePendantItem.java
@@ -31,7 +31,7 @@ public class ZanitePendantItem extends AccessoryItem {
     @Override
     public Set<ConditionalAttribute> gatherAttributes(Set<ConditionalAttribute> attributes) {
         attributes = super.gatherAttributes(attributes);
-        attributes.add(new ConditionalAttribute(Attributes.BLOCK_BREAK_SPEED, new ConditionalModifier(MINING_EFFICIENCY, (stack) -> 0.25 + (1.75 * stack.getDamageValue() / (stack.getMaxDamage() + 0.5)), AttributeModifier.Operation.ADD_VALUE), (stack, wearer) -> true));
+        attributes.add(new ConditionalAttribute(Attributes.BLOCK_BREAK_SPEED, new ConditionalModifier(MINING_EFFICIENCY, (stack) -> 0.25 + .50 * stack.getDamageValue() / (stack.getMaxDamage()), AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), (stack, wearer) -> true));
         return attributes;
     }
 

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/tools/abilities/ZaniteTool.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/tools/abilities/ZaniteTool.java
@@ -2,10 +2,8 @@ package com.aetherteam.aetherii.item.equipment.tools.abilities;
 
 import com.aetherteam.aetherii.AetherII;
 import com.aetherteam.aetherii.item.equipment.ZaniteBuff;
-import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlotGroup;
-import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.ItemStack;
@@ -13,19 +11,17 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 public interface ZaniteTool extends ZaniteBuff {
     ResourceLocation MINING_EFFICIENCY_MODIFIER_ID = ResourceLocation.fromNamespaceAndPath(AetherII.MODID, "zanite_modified_mining_efficiency");
 
     static void updateToolAttributes(ItemAttributeModifierEvent event) {
         ItemStack stack = event.getItemStack();
-        ItemAttributeModifiers defaultModifiers = event.getDefaultModifiers();
         List<ItemAttributeModifiers.Entry> modifiers = event.getModifiers();
 
         if (stack.getItem() instanceof ZaniteTool zaniteTool) {
             ItemAttributeModifiers.Entry updatedEntry = null;
-            ItemAttributeModifiers.Entry newEntry = zaniteTool.increaseSpeed(defaultModifiers, stack, 6.0F);
+            ItemAttributeModifiers.Entry newEntry = zaniteTool.increaseSpeed(stack);
             double newAmount = newEntry.modifier().amount();
             boolean flag = true;
             for (ItemAttributeModifiers.Entry oldEntry : modifiers) {
@@ -46,17 +42,7 @@ public interface ZaniteTool extends ZaniteBuff {
         }
     }
 
-    default ItemAttributeModifiers.Entry increaseSpeed(ItemAttributeModifiers modifiers, ItemStack stack, double baseValue) {
-        return new ItemAttributeModifiers.Entry(Attributes.MINING_EFFICIENCY, new AttributeModifier(MINING_EFFICIENCY_MODIFIER_ID, this.calculateSpeedIncrease(Attributes.MINING_EFFICIENCY, baseValue, MINING_EFFICIENCY_MODIFIER_ID, modifiers, stack), AttributeModifier.Operation.ADD_VALUE), EquipmentSlotGroup.MAINHAND);
-    }
-
-    default double calculateSpeedIncrease(Holder<Attribute> base, double baseValue, ResourceLocation bonusModifier, ItemAttributeModifiers modifiers, ItemStack stack) {
-        AtomicReference<Double> baseStat = new AtomicReference<>(baseValue);
-        modifiers.forEach(EquipmentSlotGroup.MAINHAND, (attribute, modifier) -> {
-            if (attribute.value() == base.value() && !modifier.id().equals(bonusModifier)) {
-                baseStat.updateAndGet(v -> v + modifier.amount());
-            }
-        });
-        return this.calculateZaniteBuff(stack, baseStat.get()) - baseStat.get();
+    default ItemAttributeModifiers.Entry increaseSpeed(ItemStack stack) {
+        return new ItemAttributeModifiers.Entry(Attributes.BLOCK_BREAK_SPEED, new AttributeModifier(MINING_EFFICIENCY_MODIFIER_ID, this.calculateZaniteBuff(stack), AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), EquipmentSlotGroup.MAINHAND);
     }
 }

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/weapons/abilities/ZaniteWeapon.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/weapons/abilities/ZaniteWeapon.java
@@ -14,7 +14,6 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 public interface ZaniteWeapon extends ZaniteBuff {
     ResourceLocation DAMAGE_MODIFIER_ID = ResourceLocation.fromNamespaceAndPath(AetherII.MODID, "zanite_modified_attack_damage");
@@ -30,12 +29,11 @@ public interface ZaniteWeapon extends ZaniteBuff {
 
     static void updateWeaponAttributes(ItemAttributeModifierEvent event) {
         ItemStack stack = event.getItemStack();
-        ItemAttributeModifiers defaultModifiers = event.getDefaultModifiers();
         List<ItemAttributeModifiers.Entry> modifiers = event.getModifiers();
 
         if (stack.getItem() instanceof ZaniteWeapon zaniteWeapon) {
             Set<ItemAttributeModifiers.Entry> updatedEntries = new HashSet<>();
-            Set<ItemAttributeModifiers.Entry> newEntries = new HashSet<>(zaniteWeapon.increaseDamage(zaniteWeapon.getDamageType(), defaultModifiers, stack));
+            Set<ItemAttributeModifiers.Entry> newEntries = new HashSet<>(zaniteWeapon.increaseDamage(zaniteWeapon.getDamageType(), stack));
             for (ItemAttributeModifiers.Entry newEntry : newEntries) {
                 boolean flag = true;
                 for (ItemAttributeModifiers.Entry oldEntry : modifiers) {
@@ -58,32 +56,13 @@ public interface ZaniteWeapon extends ZaniteBuff {
         }
     }
 
-    default List<ItemAttributeModifiers.Entry> increaseDamage(Holder<Attribute> typeAttribute, ItemAttributeModifiers modifiers, ItemStack stack) {
+    default List<ItemAttributeModifiers.Entry> increaseDamage(Holder<Attribute> typeAttribute, ItemStack stack) {
         List<ItemAttributeModifiers.Entry> modifierEntryList = new ArrayList<>();
 
-        modifierEntryList.add(new ItemAttributeModifiers.Entry(typeAttribute, new AttributeModifier(DAMAGE_TYPES.get(typeAttribute), this.calculateDamageIncrease(typeAttribute, DAMAGE_TYPES.get(typeAttribute), modifiers, stack), AttributeModifier.Operation.ADD_VALUE), EquipmentSlotGroup.MAINHAND));
-        modifierEntryList.add(new ItemAttributeModifiers.Entry(Attributes.ATTACK_DAMAGE, new AttributeModifier(DAMAGE_MODIFIER_ID, this.calculateDamageIncrease(Attributes.ATTACK_DAMAGE, DAMAGE_MODIFIER_ID, modifiers, stack), AttributeModifier.Operation.ADD_VALUE), EquipmentSlotGroup.MAINHAND));
+        modifierEntryList.add(new ItemAttributeModifiers.Entry(typeAttribute, new AttributeModifier(DAMAGE_TYPES.get(typeAttribute), this.calculateZaniteBuff(stack), AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), EquipmentSlotGroup.MAINHAND));
+        modifierEntryList.add(new ItemAttributeModifiers.Entry(Attributes.ATTACK_DAMAGE, new AttributeModifier(DAMAGE_MODIFIER_ID, this.calculateZaniteBuff(stack), AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), EquipmentSlotGroup.MAINHAND));
 
         return modifierEntryList;
-    }
-
-     default int calculateDamageIncrease(Holder<Attribute> base, ResourceLocation bonusModifier, ItemAttributeModifiers modifiers, ItemStack stack) {
-        AtomicReference<Double> baseStat = new AtomicReference<>(0.0);
-        modifiers.forEach(EquipmentSlotGroup.MAINHAND, (attribute, modifier) -> {
-            if (attribute.value() == base.value() && !modifier.id().equals(bonusModifier)) {
-                baseStat.updateAndGet(v -> v + modifier.amount());
-            }
-        });
-        return this.calculateDamageIncrease(stack, baseStat.get());
-    }
-
-    default int calculateDamageIncrease(ItemStack stack, double baseDamage) {
-        double boostedDamage = this.calculateZaniteBuff(stack, baseDamage);
-        boostedDamage -= baseDamage;
-        if (boostedDamage < 0.0) {
-            boostedDamage = 0.0;
-        }
-        return (int) Math.round(boostedDamage);
     }
 
     Holder<Attribute> getDamageType();

--- a/src/main/java/com/aetherteam/aetherii/item/equipment/weapons/zanite/ZaniteCrossbowItem.java
+++ b/src/main/java/com/aetherteam/aetherii/item/equipment/weapons/zanite/ZaniteCrossbowItem.java
@@ -23,7 +23,7 @@ public class ZaniteCrossbowItem extends TieredCrossbowItem implements ZaniteBuff
         Projectile projectile = super.createProjectile(level, shooter, weapon, ammo, isCrit);
         if (shooter.getData(AetherIIDataAttachments.ABILITY_BEHAVIOR).isCrossbowSpecial()) {
             if (projectile instanceof AbstractArrow arrow) {
-                arrow.setBaseDamage(this.calculateZaniteBuff(weapon, ((AbstractArrowAccessor) arrow).aether$getBaseDamage()));
+                arrow.setBaseDamage((this.calculateZaniteBuff(weapon) + 1) * ((AbstractArrowAccessor) arrow).aether$getBaseDamage());
             }
         }
         return projectile;


### PR DESCRIPTION
fix(zanite-equipment): Fix Zanite buff calculations

Fixes Zanite tool buffs by modifying the `BLOCK_BREAK_SPEED` attribute instead of `MINING_EFFICIENCY`. Also changed the modifier operation from `ADD_VALUE` to `ADD_MULTIPLIED_TOTAL` to show a percentage change and simplify the calculation code. Also applied this change to the rest of the equipment for consistency. 


<img width="256" height="151" alt="Screenshot_20260314_173636" src="https://github.com/user-attachments/assets/6330d7e7-7627-4f29-b96d-e95973312a98" />

I wasnt sure on how the scaling was supposed to behave but ive set the buff to linearly interpolate between +0% and +100% (let me know what the actual intended behavior is and i'm happy to fix it). I briefly tried making the crossbow implement `ZaniteWeapon` to add the tooltip, but that caused melee damage to scale with durability, so I left it out but would technically work.

Heads up: This is my first time working with a Minecraft modding API (and Java), so apologies if I’ve made any incorrect assumptions on how this all works.

---

I agree to the Contributor License Agreement (CLA).