### PR TITLE
fix(MusicPlayerItem): Music Player not stopping after leaving inventory

### DIFF
--- a/src/main/java/com/aetherteam/aetherii/item/AetherIIItems.java
+++ b/src/main/java/com/aetherteam/aetherii/item/AetherIIItems.java
@@ -460,6 +460,11 @@ public class AetherIIItems {
         // Accessories
         bus.addListener(ZanitePendantItem::onBlockBreak);
 
+        // Music Player
+        bus.addListener(MusicPlayerItem::onItemDropped);
+        bus.addListener(MusicPlayerItem::onPlayerDeath);
+        bus.addListener(MusicPlayerItem::onContainerClose);
+
         // Other
         bus.addListener(CompanionItem::entityPostTick);
         bus.addListener(CompanionItem::entityLeaveLevel);

--- a/src/main/java/com/aetherteam/aetherii/item/miscellaneous/MusicPlayerItem.java
+++ b/src/main/java/com/aetherteam/aetherii/item/miscellaneous/MusicPlayerItem.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.*;
+import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
@@ -118,8 +119,7 @@ public class MusicPlayerItem extends Item {
 
     public static void onItemDropped(ItemTossEvent event) {
         ItemStack stack = event.getEntity().getItem();
-        if (stack.getItem() instanceof MusicPlayerItem)
-            stopMusic(stack);
+        tryStopMusic(stack);
     }
 
     public static void onContainerClose(PlayerContainerEvent.Close event) {
@@ -128,22 +128,33 @@ public class MusicPlayerItem extends Item {
                 continue; // Skip slots in player inventory
 
             ItemStack stack = slot.getItem();
-
-            if (stack.getItem() instanceof MusicPlayerItem)
-                stopMusic(stack);
+            tryStopMusic(stack);
         }
     }
 
     public static void onPlayerDeath(LivingDropsEvent event) {
         for (ItemEntity itemEntity : event.getDrops()) {
             ItemStack stack = itemEntity.getItem();
-
-            if (stack.getItem() instanceof MusicPlayerItem)
-                stopMusic(stack);
+            tryStopMusic(stack);
         }
     }
 
-    public static void stopMusic(ItemStack stack){
+    private static void tryStopMusic(ItemStack stack){
+        // Check if bundle and read through its contents for a music player
+        BundleContents contents = stack.get(DataComponents.BUNDLE_CONTENTS);
+        if (contents != null) {
+            // Music player only stacks to one, so just check the first item
+            if(contents.isEmpty())
+                return;
+
+            ItemStack item = contents.getItemUnsafe(0);
+            if(item.getItem() instanceof MusicPlayerItem)
+                stack = item;
+        }
+        else if(!(stack.getItem() instanceof MusicPlayerItem)) {
+            return;
+        }
+
         StoredMusic music = stack.get(AetherIIDataComponents.STORED_MUSIC);
 
         if (music == null || !AetherIIClientProxy.isPlayingSoundEvent(music.sound().value())) {

--- a/src/main/java/com/aetherteam/aetherii/item/miscellaneous/MusicPlayerItem.java
+++ b/src/main/java/com/aetherteam/aetherii/item/miscellaneous/MusicPlayerItem.java
@@ -14,6 +14,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.Slot;
@@ -21,6 +23,9 @@ import net.minecraft.world.item.*;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.event.entity.item.ItemTossEvent;
+import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerContainerEvent;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -109,5 +114,43 @@ public class MusicPlayerItem extends Item {
                 song.addToTooltip(context, tooltipAdder, flag, stack);
             }
         }
+    }
+
+    public static void onItemDropped(ItemTossEvent event) {
+        ItemStack stack = event.getEntity().getItem();
+        if (stack.getItem() instanceof MusicPlayerItem)
+            stopMusic(stack);
+    }
+
+    public static void onContainerClose(PlayerContainerEvent.Close event) {
+        for (Slot slot : event.getContainer().slots) {
+            if (slot.container instanceof Inventory)
+                continue; // Skip slots in player inventory
+
+            ItemStack stack = slot.getItem();
+
+            if (stack.getItem() instanceof MusicPlayerItem)
+                stopMusic(stack);
+        }
+    }
+
+    public static void onPlayerDeath(LivingDropsEvent event) {
+        for (ItemEntity itemEntity : event.getDrops()) {
+            ItemStack stack = itemEntity.getItem();
+
+            if (stack.getItem() instanceof MusicPlayerItem)
+                stopMusic(stack);
+        }
+    }
+
+    public static void stopMusic(ItemStack stack){
+        StoredMusic music = stack.get(AetherIIDataComponents.STORED_MUSIC);
+
+        if (music == null || !AetherIIClientProxy.isPlayingSoundEvent(music.sound().value())) {
+            return;
+        }
+
+        Holder<SoundEvent> sound = Holder.direct(SoundEvent.createVariableRangeEvent(music.sound().value().location()));
+        AetherIIClientProxy.stopSoundEvent(sound.value(), SoundSource.RECORDS);
     }
 }


### PR DESCRIPTION
As I said in another PR i submitted, i am very new to java and MC modding.

It'll stop playing when the player is dropped, when you die and when you put it in an inventory slot that isn't a players (but only when you close that inventory screen). It'll also work if a music player (for what ever reason) is in a bundle.

I haven't figured out how to make it stop immediately when its placed into a new inventory, or if an inventory is cleared using `/clear` or clearing in the creative screen, and I'm not sure of there's any other cases i should be handling.

closes issue #756

---

I agree to the Contributor License Agreement (CLA).