### PR TITLE
fix: sodium and iris compat (1.21.8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,9 @@ dependencies {
 
     implementation "mezz.jei:jei-${project.minecraft_version}-neoforge:${project.jei_version}"
 
+    compileOnly "maven.modrinth:sodium:${project.sodium_version}"
+    compileOnly "maven.modrinth:iris:${project.iris_version}"
+
 //    runtimeOnly "io.github.flemmli97:debugutils:1.21-${project.debugutils_version}-neoforge"
 
     //compileOnly fileTree(dir: 'libs', include: '*.jar')
@@ -123,6 +126,7 @@ repositories {
     maven { url = "https://www.cursemaven.com" }
     maven { url = "https://packages.aether-mod.net/Nitrogen" }
     maven { url = "https://packages.aether-mod.net/Cumulus" }
+    maven { url = "https://api.modrinth.com/maven" }
     mavenLocal()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 org.gradle.debug=false
 
+
 neoForge.parchment.minecraftVersion=1.21.8
 neoForge.parchment.mappingsVersion=2025.07.20
 
@@ -31,6 +32,10 @@ cumulus_version=1.21.8-2.0.8-neoforge
 #accessories_version=1.2.19-beta
 #debugutils_version=1.0.6
 jei_version=24.2.0.6
+
+# compileOnly dependencies
+sodium_version=mc1.21.8-0.7.3-neoforge
+iris_version=1.9.6+1.21.8-neoforge
 
 # Publishing
 curseforge_id=223796

--- a/src/main/java/com/aetherteam/aetherii/client/renderer/AetherIIRenderTypes.java
+++ b/src/main/java/com/aetherteam/aetherii/client/renderer/AetherIIRenderTypes.java
@@ -14,17 +14,22 @@ import java.util.function.BiFunction;
 public class AetherIIRenderTypes {
     public static final ResourceLocation IRRADIATED_GLINT_ITEM = ResourceLocation.fromNamespaceAndPath(AetherII.MODID, "textures/misc/irradiated_glint_item.png");
 
-    public static final BiFunction<ResourceLocation, Boolean, RenderType> ENTITY_DITHER_NO_CULL = Util.memoize((location, outline) -> RenderType.create(
-            "aether:entity_dither_no_cull",
-            1536,
-            true,
-            false,
-            AetherIIRenderPipelines.getEntityDitherNoCull(),
-            RenderType.CompositeState.builder()
-                    .setTextureState(new RenderStateShard.TextureStateShard(location, false))
-                    .setLightmapState(RenderType.LIGHTMAP)
-                    .setOverlayState(RenderType.OVERLAY)
-                    .createCompositeState(outline)));
+    public static final BiFunction<ResourceLocation, Boolean, RenderType> ENTITY_DITHER_NO_CULL = Util.memoize((location, outline) -> {
+        if (ShaderCompatibility.areShadersActive()) {
+            return RenderType.entityTranslucent(location, outline);
+        }
+        return RenderType.create(
+                "aether:entity_dither_no_cull",
+                1536,
+                true,
+                false,
+                AetherIIRenderPipelines.getEntityDitherNoCull(),
+                RenderType.CompositeState.builder()
+                        .setTextureState(new RenderStateShard.TextureStateShard(location, false))
+                        .setLightmapState(RenderType.LIGHTMAP)
+                        .setOverlayState(RenderType.OVERLAY)
+                        .createCompositeState(outline));
+    });
 
     private static final RenderType CLOUD_COVER = RenderType.create(
             "aether:cloud_cover",

--- a/src/main/java/com/aetherteam/aetherii/client/renderer/AetherIIRenderTypes.java
+++ b/src/main/java/com/aetherteam/aetherii/client/renderer/AetherIIRenderTypes.java
@@ -2,19 +2,16 @@ package com.aetherteam.aetherii.client.renderer;
 
 import com.aetherteam.aetherii.AetherII;
 import com.aetherteam.aetherii.client.AetherIIRenderPipelines;
-import net.minecraft.Util;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.client.event.RegisterRenderBuffersEvent;
 
-import java.util.function.BiFunction;
-
 public class AetherIIRenderTypes {
     public static final ResourceLocation IRRADIATED_GLINT_ITEM = ResourceLocation.fromNamespaceAndPath(AetherII.MODID, "textures/misc/irradiated_glint_item.png");
 
-    public static final BiFunction<ResourceLocation, Boolean, RenderType> ENTITY_DITHER_NO_CULL = Util.memoize((location, outline) -> {
+    private static RenderType createEntityDitherNoCull(ResourceLocation location, boolean outline) {
         if (ShaderCompatibility.areShadersActive()) {
             return RenderType.entityTranslucent(location, outline);
         }
@@ -29,7 +26,7 @@ public class AetherIIRenderTypes {
                         .setLightmapState(RenderType.LIGHTMAP)
                         .setOverlayState(RenderType.OVERLAY)
                         .createCompositeState(outline));
-    });
+    }
 
     private static final RenderType CLOUD_COVER = RenderType.create(
             "aether:cloud_cover",
@@ -48,11 +45,11 @@ public class AetherIIRenderTypes {
                     .createCompositeState(false));
 
     public static RenderType entityDitherNoCull(ResourceLocation location) {
-        return ENTITY_DITHER_NO_CULL.apply(location, true);
+        return createEntityDitherNoCull(location, true);
     }
 
     public static RenderType entityDitherNoCull(ResourceLocation location, boolean outline) {
-        return ENTITY_DITHER_NO_CULL.apply(location, outline);
+        return createEntityDitherNoCull(location, outline);
     }
 
     public static RenderType cloudCover() {

--- a/src/main/java/com/aetherteam/aetherii/client/renderer/ShaderCompatibility.java
+++ b/src/main/java/com/aetherteam/aetherii/client/renderer/ShaderCompatibility.java
@@ -1,0 +1,18 @@
+package com.aetherteam.aetherii.client.renderer;
+
+import net.irisshaders.iris.api.v0.IrisApi;
+import net.neoforged.fml.ModList;
+
+public class ShaderCompatibility {
+    private static Boolean irisLoaded = null;
+
+    public static boolean areShadersActive() {
+        if (irisLoaded == null) {
+            irisLoaded = ModList.get().isLoaded("iris");
+        }
+        if (irisLoaded) {
+            return IrisApi.getInstance().isShaderPackInUse();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/aetherteam/aetherii/mixin/AetherIIMixinPlugin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/AetherIIMixinPlugin.java
@@ -32,7 +32,8 @@ public class AetherIIMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (mixinClassName.equals("com.aetherteam.aetherii.mixin.mixins.client.sodium.ChunkBuilderMeshingTaskMixin")) {
+        if (mixinClassName.equals("com.aetherteam.aetherii.mixin.mixins.client.sodium.ChunkBuilderMeshingTaskMixin")
+                || mixinClassName.equals("com.aetherteam.aetherii.mixin.mixins.client.sodium.DefaultFluidRendererMixin")) {
             return isSodiumInstalled;
         }
 

--- a/src/main/java/com/aetherteam/aetherii/mixin/AetherIIMixinPlugin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/AetherIIMixinPlugin.java
@@ -9,12 +9,18 @@ import java.util.Set;
 
 public class AetherIIMixinPlugin implements IMixinConfigPlugin {
     private boolean isOptiFineInstalled = false;
+    private boolean isSodiumInstalled = false;
 
     @Override
     public void onLoad(String mixinPackage) {
         try {
             Class.forName("optifine.Installer", false, getClass().getClassLoader());
             isOptiFineInstalled = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        try {
+            Class.forName("net.caffeinemc.mods.sodium.client.SodiumClientMod", false, getClass().getClassLoader());
+            isSodiumInstalled = true;
         } catch (ClassNotFoundException ignored) {
         }
     }
@@ -26,6 +32,10 @@ public class AetherIIMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("com.aetherteam.aetherii.mixin.mixins.client.sodium.ChunkBuilderMeshingTaskMixin")) {
+            return isSodiumInstalled;
+        }
+
         if (this.isOptiFineInstalled) {
             if (mixinClassName.equals("com.aetherteam.aether.mixin.mixins.client.BossHealthOverlayMixin")) return false;
             if (mixinClassName.equals("com.aetherteam.aether.mixin.mixins.client.optifine.BossHealthOverlayMixin")) return true;

--- a/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/ChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/ChunkBuilderMeshingTaskMixin.java
@@ -1,0 +1,35 @@
+package com.aetherteam.aetherii.mixin.mixins.client.sodium;
+
+import com.aetherteam.aetherii.block.AetherIIBlocks;
+import com.aetherteam.aetherii.block.natural.AetherGrassBlock;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+@Mixin(targets = "net.caffeinemc.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderMeshingTask")
+public class ChunkBuilderMeshingTaskMixin {
+
+    @WrapOperation(
+        method = "execute",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer;renderModel(Lnet/minecraft/client/renderer/block/model/BlockStateModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;)V",
+            remap = false
+        ),
+        remap = false
+    )
+    private void aetherii$renderSnowOverlay(@Coerce Object instance, BlockStateModel model, BlockState state, BlockPos pos, BlockPos origin, Operation<Void> original) {
+        original.call(instance, model, state, pos, origin);
+        if (AetherGrassBlock.plantIsSnowed(state)) {
+            BlockState snow = AetherIIBlocks.ARCTIC_SNOW.get().defaultBlockState();
+            BlockStateModel snowModel = Minecraft.getInstance().getBlockRenderer().getBlockModel(snow);
+            original.call(instance, snowModel, snow, pos, origin);
+        }
+    }
+}

--- a/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/DefaultFluidRendererMixin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/DefaultFluidRendererMixin.java
@@ -1,0 +1,62 @@
+package com.aetherteam.aetherii.mixin.mixins.client.sodium;
+
+import com.aetherteam.aetherii.client.renderer.level.HolyIslesSpecialEffects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.caffeinemc.mods.sodium.client.model.quad.ModelQuadView;
+
+@Mixin(targets = "net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.DefaultFluidRenderer")
+public class DefaultFluidRendererMixin {
+
+    @Shadow(remap = false)
+    private int[] quadColors;
+
+    @Inject(method = "updateQuad", at = @At("TAIL"), remap = false)
+    private void aetherii$updateQuadAlpha(@Coerce Object quad, @Coerce Object level, BlockPos pos,
+            @Coerce Object lighter, Direction dir,
+            @Coerce Object facing, float brightness, @Coerce Object colorProvider, FluidState fluidState,
+            CallbackInfo ci) {
+
+        ClientLevel clientLevel = Minecraft.getInstance().level;
+        boolean aetherEffects = clientLevel != null && clientLevel.effects() instanceof HolyIslesSpecialEffects;
+
+        if (aetherEffects) {
+            int bottomY = clientLevel.getMinY();
+            int currentY = pos.getY();
+            int range = 8;
+            float opacityStep = 1.0F / range;
+            int max = bottomY + range;
+
+            if (currentY < max) {
+                float offsetY = currentY - bottomY;
+
+                ModelQuadView quadView = (ModelQuadView) quad;
+
+                for (int i = 0; i < 4; i++) {
+                    float y = quadView.getY(i);
+                    boolean isUpperVertex = y > 0.005F;
+                    float trueAlpha = isUpperVertex ? opacityStep * (offsetY + 1) : opacityStep * offsetY;
+
+                    trueAlpha = Math.max(0.0F, Math.min(1.0F, trueAlpha));
+
+                    int abgr = this.quadColors[i];
+                    int origAlpha = (abgr >> 24) & 0xFF;
+                    int newAlpha = (int) (origAlpha * trueAlpha);
+
+                    newAlpha = Math.max(0, Math.min(255, newAlpha));
+
+                    this.quadColors[i] = (abgr & 0x00FFFFFF) | (newAlpha << 24);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/LevelBiomeSliceMixin.java
+++ b/src/main/java/com/aetherteam/aetherii/mixin/mixins/client/sodium/LevelBiomeSliceMixin.java
@@ -1,0 +1,32 @@
+package com.aetherteam.aetherii.mixin.mixins.client.sodium;
+
+import com.aetherteam.aetherii.client.AetherIIClientProxy;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.caffeinemc.mods.sodium.client.world.biome.LevelBiomeSlice;
+import net.caffeinemc.mods.sodium.client.world.cloned.ChunkRenderContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(targets = "net.caffeinemc.mods.sodium.client.world.biome.LevelBiomeSlice")
+public abstract class LevelBiomeSliceMixin {
+
+    @Shadow(remap = false)
+    protected abstract void copySectionBiomeData(ChunkRenderContext context, int sectionX, int sectionY, int sectionZ, Holder<Biome> defaultBiome);
+
+    @Redirect(method = "copyBiomeData", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/world/biome/LevelBiomeSlice;copySectionBiomeData(Lnet/caffeinemc/mods/sodium/client/world/cloned/ChunkRenderContext;IIILnet/minecraft/core/Holder;)V"), remap = false)
+    private void aetherii$protectBoundarySections(LevelBiomeSlice instance, ChunkRenderContext context, int sectionX, int sectionY, int sectionZ, Holder<Biome> defaultBiome, @Local(argsOnly = true) Level level) {
+        if (AetherIIClientProxy.isHolyIslesSpecialEffects(level)) {
+            int absoluteY = (context.getOrigin().getY() - 1) + sectionY;
+            if (absoluteY < level.getMinSectionY()) {
+                defaultBiome = level.getBiome(context.getOrigin().center());
+            }
+        }
+
+        this.copySectionBiomeData(context, sectionX, sectionY, sectionZ, defaultBiome);
+    }
+}

--- a/src/main/resources/aether_ii.mixins.json
+++ b/src/main/resources/aether_ii.mixins.json
@@ -93,6 +93,7 @@
     "client.accessor.TitleScreenAccessor",
     "client.accessor.WeatherEffectRendererAccessor",
     "client.accessor.WeighedSoundEventsAccessor",
+    "client.sodium.ChunkBuilderMeshingTaskMixin",
     "debug.DebugRendererMixin"
   ],
   "injectors": {

--- a/src/main/resources/aether_ii.mixins.json
+++ b/src/main/resources/aether_ii.mixins.json
@@ -95,6 +95,7 @@
     "client.accessor.WeighedSoundEventsAccessor",
     "client.sodium.ChunkBuilderMeshingTaskMixin",
     "client.sodium.DefaultFluidRendererMixin",
+    "client.sodium.LevelBiomeSliceMixin",
     "debug.DebugRendererMixin"
   ],
   "injectors": {

--- a/src/main/resources/aether_ii.mixins.json
+++ b/src/main/resources/aether_ii.mixins.json
@@ -94,6 +94,7 @@
     "client.accessor.WeatherEffectRendererAccessor",
     "client.accessor.WeighedSoundEventsAccessor",
     "client.sodium.ChunkBuilderMeshingTaskMixin",
+    "client.sodium.DefaultFluidRendererMixin",
     "debug.DebugRendererMixin"
   ],
   "injectors": {


### PR DESCRIPTION
fix: sodium iris compat

Environment
- Sodium 0.7.3
- Iris 1.9.6
- Complementary Shaders - Reimagined r5.7.1 (referred to as `CSR`)

Issues Fixed
- Fixed an issue where `arctic_snow` for plants with `snowly=true` (e.g., Tarabloom) was not rendering with Sodium.
- Fixed an issue where the water gradient near the void in the `aether_ii:aether_holy_isles` dimension was not working with Sodium.
- Fixed an issue where the water color near the void in the `aether_ii:aether_holy_isles` dimension would fallback to the `Plains` biome regardless of the actual biome when using Sodium.
- Fixed an issue where `Moas` and `Aerbunnies` became invisible when using Iris and `CSR`.

Unresolved Issues and Reasons
- The following two features do not function when both Iris and `CSR` are active:
    1. Water gradient near the void in the `aether_ii:aether_holy_isles` dimension.
    2. `Moas` and `Aerbunnies` do not appear partially transparent (to improve visibility for the rider) as they do in the non-shader version.

Reasoning:
1. `CSR` fixes the vertex color alpha value to `1.0` (likely at line 164 of `gbuffers_water.glsl`), which prevents the gradient from functioning.
2. In `AetherIIRenderTypes`, the `RenderType` is forced to `entityTranslucent` when shaders are detected to resolve the invisibility issue.

The first issue is likely on the shader side.
Regarding the second issue, since the shader does not fully support the mod's custom rendering, `entityTranslucent` is used as a temporary workaround to provide the best possible experience.

Concerns
- This code has not been tested in a 1.21.1 environment, so its compatibility and functionality in that version are not guaranteed.
- I was unable to reproduce the issue "Biome Fog is broken with shaders applied" reported in [#799](https://github.com/The-Aether-Team/The-Aether-II/issues/799).

---

I agree to the Contributor License Agreement (CLA).