### PR TITLE
improv: restored previous aether sunset and sunrise colors

### DIFF
--- a/src/generated/resources/data/aether_ii/tags/worldgen/biome/modified_sunrise_sunrise_colors.json
+++ b/src/generated/resources/data/aether_ii/tags/worldgen/biome/modified_sunrise_sunrise_colors.json
@@ -1,0 +1,20 @@
+{
+  "values": [
+    "aether_ii:flourishing_field",
+    "aether_ii:verdant_woods",
+    "aether_ii:shrouded_forest",
+    "aether_ii:shimmering_basin",
+    "aether_ii:magnetic_scar",
+    "aether_ii:turquoise_forest",
+    "aether_ii:glistening_swamp",
+    "aether_ii:violet_highwoods",
+    "aether_ii:frigid_sierra",
+    "aether_ii:enduring_woodland",
+    "aether_ii:frozen_lakes",
+    "aether_ii:sheer_tundra",
+    "aether_ii:contaminated_jungle",
+    "aether_ii:battleground_wastes",
+    "aether_ii:expanse",
+    "aether_ii:hestveil_caverns"
+  ]
+}

--- a/src/main/java/com/aetherteam/aetherii/AetherIITags.java
+++ b/src/main/java/com/aetherteam/aetherii/AetherIITags.java
@@ -309,6 +309,8 @@ public class AetherIITags {
 
         public static final TagKey<Biome> AETHER_MUSIC = tag("aether_music");
 
+        public static final TagKey<Biome> MODIFIED_SUNRISE_SUNSET_COLORS = tag("modified_sunrise_sunrise_colors");
+
         private static TagKey<Biome> tag(String name) {
             return TagKey.create(Registries.BIOME, Identifier.fromNamespaceAndPath(AetherII.MODID, name));
         }

--- a/src/main/java/com/aetherteam/aetherii/client/AetherIIClient.java
+++ b/src/main/java/com/aetherteam/aetherii/client/AetherIIClient.java
@@ -57,6 +57,7 @@ public class AetherIIClient {
         AetherIIClientEventListeners.listen(bus);
 
         bus.addListener(DimensionClientListener::onRenderFog);
+        bus.addListener(DimensionClientListener::onFogColorComputed);
         bus.addListener(LevelClientListener::onRenderLevelLast);
         bus.addListener(AetherIIDimensionRenderers::extractDimensionEffect);
 

--- a/src/main/java/com/aetherteam/aetherii/client/event/listeners/DimensionClientListener.java
+++ b/src/main/java/com/aetherteam/aetherii/client/event/listeners/DimensionClientListener.java
@@ -1,14 +1,21 @@
 package com.aetherteam.aetherii.client.event.listeners;
 
 import com.aetherteam.aetherii.AetherIITags;
+import com.aetherteam.aetherii.client.renderer.level.AetherSkyboxRenderer;
 import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.PanoramicScreenshotParameters;
 import net.minecraft.core.Holder;
+import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
+import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.material.FogType;
 import net.neoforged.neoforge.client.event.ViewportEvent;
 import net.neoforged.neoforge.common.NeoForgeMod;
+import org.joml.Vector3fc;
 
 public class DimensionClientListener {
     private static Float modifiedNearDistance = null;
@@ -62,5 +69,73 @@ public class DimensionClientListener {
                 modifiedFarDistance = null;
             }
         }
+    }
+
+    public static void onFogColorComputed(ViewportEvent.ComputeFogColor event) {
+        Camera camera = event.getCamera();
+        DeltaTracker deltaTracker = DeltaTracker.ONE;
+        float f = deltaTracker.getGameTimeDeltaPartialTick(false);
+
+        if (camera.entity().level() instanceof ClientLevel clientLevel) {
+            Holder<Biome> biome = clientLevel.getBiome(camera.blockPosition());
+            if (biome.is(AetherIITags.Biomes.MODIFIED_SUNRISE_SUNSET_COLORS)) {
+                int i = getBaseFogColor(clientLevel, camera, event.getRenderer().getMinecraft().options.getEffectiveRenderDistance(), f);
+                event.setRed(ARGB.redFloat(i));
+                event.setGreen(ARGB.greenFloat(i));
+                event.setBlue(ARGB.blueFloat(i));
+            }
+        }
+    }
+
+    /**
+     * [CODE COPY] - {@link net.minecraft.client.renderer.fog.environment.AtmosphericFogEnvironment#getBaseColor(ClientLevel, Camera, int, float)}.
+     */
+    public static int getBaseFogColor(ClientLevel clientLevel, Camera camera, int effectiveRenderDistance, float partialTick) {
+        float timeOfDay = timeOfDay(clientLevel.getDayTime());
+        int i = camera.attributeProbe().getValue(EnvironmentAttributes.FOG_COLOR, partialTick);
+        float f4;
+        if (new AetherSkyboxRenderer().isSunriseOrSunset(timeOfDay)) {
+            if (effectiveRenderDistance >= 4) {
+                float f = camera.attributeProbe().getValue(EnvironmentAttributes.SUN_ANGLE, partialTick) * 0.017453292F;
+                f4 = Mth.sin(f) > 0.0F ? -1.0F : 1.0F;
+                PanoramicScreenshotParameters panorama = Minecraft.getInstance().gameRenderer.getPanoramicScreenshotParameters();
+                Vector3fc vector3fc = panorama != null ? panorama.forwardVector() : camera.forwardVector();
+                float f2 = vector3fc.dot(f4, 0.0F, 0.0F);
+                if (f2 > 0.0F) {
+                    int j = new AetherSkyboxRenderer().getSunriseOrSunsetColor(timeOfDay); //Modifies the sunrise/sunset fog colors to use the Aether's sunrise/sunset fog colors
+                    float f3 = ARGB.alphaFloat(j);
+                    if (f3 > 0.0F) {
+                        i = ARGB.srgbLerp(f2 * f3, i, ARGB.opaque(j));
+                    }
+                }
+            }
+        }
+
+        int skyColor = camera.attributeProbe().getValue(EnvironmentAttributes.SKY_COLOR, partialTick);
+        skyColor  = applyWeatherDarken(skyColor , clientLevel.getRainLevel(partialTick), clientLevel.getThunderLevel(partialTick));
+        f4 = Math.min(camera.attributeProbe().getValue(EnvironmentAttributes.SKY_FOG_END_DISTANCE, partialTick) / 16.0F, (float) effectiveRenderDistance);
+        float f5 = Mth.clampedLerp(f4 / 32.0F, 0.25F, 1.0F);
+        f5 = 1.0F - (float) Math.pow(f5, 0.25);
+        return ARGB.srgbLerp(f5, i, skyColor);
+    }
+
+    private static int applyWeatherDarken(int skyColor, float rainLevel, float thunderLevel) {
+        if (rainLevel > 0.0F) {
+            float f = 1.0F - rainLevel * 0.5F;
+            float f1 = 1.0F - rainLevel * 0.4F;
+            skyColor = ARGB.scaleRGB(skyColor, f, f, f1);
+        }
+
+        if (thunderLevel > 0.0F) {
+            skyColor = ARGB.scaleRGB(skyColor, 1.0F - thunderLevel * 0.5F);
+        }
+
+        return skyColor;
+    }
+
+    public static float timeOfDay(long dayTime) {
+        double d0 = Mth.frac((double) dayTime / (double) 24000.0F - (double) 0.25F);
+        double d1 = (double) 0.5F - Math.cos(d0 * Math.PI) / (double) 2.0F;
+        return (float) (d0 * (double) 2.0F + d1) / 3.0F;
     }
 }

--- a/src/main/java/com/aetherteam/aetherii/client/renderer/level/AetherSkyboxRenderer.java
+++ b/src/main/java/com/aetherteam/aetherii/client/renderer/level/AetherSkyboxRenderer.java
@@ -26,11 +26,11 @@ public class AetherSkyboxRenderer implements CustomSkyboxRenderer {
         SkyRenderer skyRenderer = ((LevelRendererAccessor) Minecraft.getInstance().levelRenderer).aether_ii$getSkyRenderer();
         setupFog.run();
         PoseStack poseStack = new PoseStack();
+        float timeOfDay = levelRenderState.getRenderDataOrDefault(AetherIIDimensionRenderers.DATA_TIME_OF_DAY_KEY, 0.0F);
         float sunAngle = skyRenderState.sunAngle;
-        int sunColor = skyRenderState.sunriseAndSunsetColor;
+        int sunColor = getSunriseOrSunsetColor(timeOfDay);
         skyRenderer.renderSkyDisc(skyRenderState.skyColor);
         MultiBufferSource.BufferSource multiBufferSource = renderBuffers.bufferSource();
-        float timeOfDay = levelRenderState.getRenderDataOrDefault(AetherIIDimensionRenderers.DATA_TIME_OF_DAY_KEY, 0.0F);
         if (this.isSunriseOrSunset(timeOfDay)) {
             skyRenderer.renderSunriseAndSunset(poseStack, sunAngle, sunColor);
         }
@@ -40,12 +40,12 @@ public class AetherSkyboxRenderer implements CustomSkyboxRenderer {
                 skyRenderState.moonPhase,
                 skyRenderState.rainBrightness,
                 skyRenderState.starBrightness);
-        this.renderCloudCoverDisc(levelRenderState, skyRenderState, poseStack, multiBufferSource, timeOfDay, skyRenderState.skyColor, skyRenderState.sunriseAndSunsetColor);
+        this.renderCloudCoverDisc(levelRenderState, poseStack, multiBufferSource, timeOfDay, skyRenderState.skyColor, skyRenderState.sunriseAndSunsetColor);
         multiBufferSource.endBatch();
         return true;
     }
 
-    public void renderCloudCoverDisc(LevelRenderState levelRenderState, SkyRenderState skyRenderState, PoseStack poseStack, MultiBufferSource.BufferSource multiBufferSource, float timeOfDay, int skyColor, int sunColor) {
+    public void renderCloudCoverDisc(LevelRenderState levelRenderState, PoseStack poseStack, MultiBufferSource.BufferSource multiBufferSource, float timeOfDay, int skyColor, int sunColor) {
         poseStack.pushPose();
         poseStack.mulPose(Axis.XP.rotationDegrees(0.0F));
         poseStack.mulPose(Axis.ZP.rotationDegrees(0.0F));
@@ -100,4 +100,10 @@ public class AetherSkyboxRenderer implements CustomSkyboxRenderer {
         return f >= -0.4F && f <= 0.4F;
     }
 
+    public int getSunriseOrSunsetColor(float timeOfDay) {
+        float f = Mth.cos(timeOfDay * Mth.TWO_PI);
+        float f1 = f / 0.4F * 0.5F + 0.5F;
+        float f2 = Mth.square(1.0F - (1.0F - Mth.sin(f1 * Mth.PI)) * 0.99F);
+        return ARGB.colorFromFloat(f2, f1 * 0.3F + 0.65F, f1 * f1 * 0.7F + 0.25F, 0.4F);
+    }
 }

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBiomeTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBiomeTagData.java
@@ -102,6 +102,25 @@ public class AetherIIBiomeTagData extends BiomeTagsProvider {
                 HolyIslesBiomes.HESTVEIL_CAVERNS
         );
 
+        this.tag(AetherIITags.Biomes.MODIFIED_SUNRISE_SUNSET_COLORS).add(
+                HolyIslesBiomes.FLOURISHING_FIELD,
+                HolyIslesBiomes.VERDANT_WOODS,
+                HolyIslesBiomes.SHROUDED_FOREST,
+                HolyIslesBiomes.SHIMMERING_BASIN,
+                HolyIslesBiomes.MAGNETIC_SCAR,
+                HolyIslesBiomes.TURQUOISE_FOREST,
+                HolyIslesBiomes.GLISTENING_SWAMP,
+                HolyIslesBiomes.VIOLET_HIGHWOODS,
+                HolyIslesBiomes.FRIGID_SIERRA,
+                HolyIslesBiomes.ENDURING_WOODLAND,
+                HolyIslesBiomes.FROZEN_LAKES,
+                HolyIslesBiomes.SHEER_TUNDRA,
+                HolyIslesBiomes.CONTAMINATED_JUNGLE,
+                HolyIslesBiomes.BATTLEGROUND_WASTES,
+                HolyIslesBiomes.EXPANSE,
+                HolyIslesBiomes.HESTVEIL_CAVERNS
+        );
+
         this.tag(AetherIITags.Biomes.HAS_STRUCTURE_OUTPOST).add(
                 HolyIslesBiomes.FLOURISHING_FIELD,
                 HolyIslesBiomes.VERDANT_WOODS,


### PR DESCRIPTION
sunsets and sunrises in the aether now use softer shades of orange again as compared to the overworld like they did in 1.21.8