### PR TITLE
improv: added overworld blocks to portal whitelist

### DIFF
--- a/src/generated/resources/data/aether_ii/tags/block/aether_portal_whitelist.json
+++ b/src/generated/resources/data/aether_ii/tags/block/aether_portal_whitelist.json
@@ -21,6 +21,14 @@
     "minecraft:coarse_dirt",
     "minecraft:snow",
     "minecraft:snow_block",
-    "#minecraft:flowers"
+    "minecraft:short_grass",
+    "minecraft:short_dry_grass",
+    "minecraft:tall_dry_grass",
+    "minecraft:fern",
+    "minecraft:bush",
+    "minecraft:dead_bush",
+    "minecraft:snow_block",
+    "#minecraft:flowers",
+    "#minecraft:terracotta"
   ]
 }

--- a/src/generated/resources/data/aether_ii/tags/block/aether_portal_whitelist.json
+++ b/src/generated/resources/data/aether_ii/tags/block/aether_portal_whitelist.json
@@ -3,7 +3,6 @@
     "aether_ii:aether_grass_block",
     "aether_ii:enchanted_aether_grass_block",
     "aether_ii:aether_dirt",
-    "aether_ii:quicksoil",
     "aether_ii:ferrosite_sand",
     "aether_ii:ferrosite_mud",
     "aether_ii:arctic_snow",
@@ -16,6 +15,12 @@
     "aether_ii:holystone_rock",
     "aether_ii:skyroot_twig",
     "aether_ii:valkyrie_sprout",
+    "minecraft:grass_block",
+    "minecraft:sand",
+    "minecraft:podzol",
+    "minecraft:coarse_dirt",
+    "minecraft:snow",
+    "minecraft:snow_block",
     "#minecraft:flowers"
   ]
 }

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -45,7 +45,6 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.AETHER_GRASS_BLOCK.get(),
                 AetherIIBlocks.ENCHANTED_AETHER_GRASS_BLOCK.get(),
                 AetherIIBlocks.AETHER_DIRT.get(),
-                AetherIIBlocks.QUICKSOIL.get(),
                 AetherIIBlocks.FERROSITE_SAND.get(),
                 AetherIIBlocks.FERROSITE_MUD.get(),
                 AetherIIBlocks.ARCTIC_SNOW.get(),
@@ -57,7 +56,13 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.AETHER_BUSH.get(),
                 AetherIIBlocks.HOLYSTONE_ROCK.get(),
                 AetherIIBlocks.SKYROOT_TWIG.get(),
-                AetherIIBlocks.VALKYRIE_SPROUT.get()
+                AetherIIBlocks.VALKYRIE_SPROUT.get(),
+                Blocks.GRASS_BLOCK,
+                Blocks.SAND,
+                Blocks.PODZOL,
+                Blocks.COARSE_DIRT,
+                Blocks.SNOW,
+                Blocks.SNOW_BLOCK
         ).addTag(BlockTags.FLOWERS);
         this.tag(AetherIITags.Blocks.UNDERSHALE).add(AetherIIBlocks.UNDERSHALE.get());
         this.tag(AetherIITags.Blocks.AETHER_UNDERGROUND_BLOCKS).add(

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -62,8 +62,15 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 Blocks.PODZOL,
                 Blocks.COARSE_DIRT,
                 Blocks.SNOW,
+                Blocks.SNOW_BLOCK,
+                Blocks.SHORT_GRASS,
+                Blocks.SHORT_DRY_GRASS,
+                Blocks.TALL_DRY_GRASS,
+                Blocks.FERN,
+                Blocks.BUSH,
+                Blocks.DEAD_BUSH,
                 Blocks.SNOW_BLOCK
-        ).addTag(BlockTags.FLOWERS);
+        ).addTags(BlockTags.FLOWERS, BlockTags.TERRACOTTA);
         this.tag(AetherIITags.Blocks.UNDERSHALE).add(AetherIIBlocks.UNDERSHALE.get());
         this.tag(AetherIITags.Blocks.AETHER_UNDERGROUND_BLOCKS).add(
                 AetherIIBlocks.HOLYSTONE.get(),


### PR DESCRIPTION
added grass, sand, podzol, coarse dirt, snow, and snow blocks to the portal whitelist