### PR TITLE
fix: add relocation_not_supported to gravitite_ability_blacklist tag

### DIFF
--- a/src/generated/resources/data/aether_ii/tags/block/gravitite_ability_blacklist.json
+++ b/src/generated/resources/data/aether_ii/tags/block/gravitite_ability_blacklist.json
@@ -11,6 +11,7 @@
     "aether_ii:aechor_cutting",
     "aether_ii:brettl_flower",
     "aether_ii:sentry_spawner",
-    "aether_ii:sentry_trap"
+    "aether_ii:sentry_trap",
+    "#c:relocation_not_supported"
   ]
 }

--- a/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
+++ b/src/main/java/com/aetherteam/aetherii/data/generators/tags/AetherIIBlockTagData.java
@@ -162,6 +162,8 @@ public class AetherIIBlockTagData extends BlockTagsProvider {
                 AetherIIBlocks.BRETTL_FLOWER.get(),
                 AetherIIBlocks.SENTRY_SPAWNER.get(),
                 AetherIIBlocks.SENTRY_TRAP.get()
+        ).addTags(
+                Tags.Blocks.RELOCATION_NOT_SUPPORTED
         );
 
         this.tag(AetherIITags.Blocks.AETHER_ANIMALS_SPAWNABLE_ON).add(


### PR DESCRIPTION
closes #999 
